### PR TITLE
Add a `tiledb-cf` command line interface tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,35 @@ or from [PyPI](https://pypi.org/project/tiledb/) with ``pip``:
 
 ```bash
 pip install tiledb-cf
+
+```
+
+## Command Line Interface
+
+TileDB-CF provides a command line interface. Currently, it has the following commands:
+
+```bash
+Usage: tiledb-cf netcdf-convert [OPTIONS]
+
+  Converts a NetCDF input file to nested TileDB groups.
+
+Options:
+  -i, --input-file TEXT           The path or URI to the NetCDF file that will be converted.  [required]
+
+  -o, --output-uri TEXT           The URI for the output TileDB group. [required]
+
+  --input-group-path TEXT         The path in the input NetCDF for the root group that will be converted.  [default: /]
+
+  --recursive / --no-recursive    Recursively convert all groups contained in the input group path.  [default: True]
+
+  -k, --output-key TEXT           Key for the generated TileDB arrays.
+
+  --unlimited-dim-size INTEGER    Size to convert unlimited dimensions to. [default: 10000]
+
+  --dim-dtype [int8|int16|int32|int64|uint8|uint16|uint32|uint64]
+                                  The data type for TileDB dimensions created from converted NetCDF.  [default: uint64]
+
+  --help                          Show this message and exit.
 ```
 
 ## Development

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -21,7 +21,7 @@ All external class and functions in the TileDB-CF library are available in this 
 NetCDF Auto-convert Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autofunction:: tiledb.cf.from_netcdf_file
+.. autofunction:: tiledb.cf.from_netcdf
    :noindex:
 
 .. autofunction:: tiledb.cf.from_netcdf_group

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     numpy >= 1.16.5
     setuptools >= 40.4
     tiledb >= 0.8.3
+    click >= 0.7.0
 
 [options.extras_require]
 docs =
@@ -42,6 +43,10 @@ docs =
      sphinx-rtd-theme
 
 netCDF4 = netCDF4
+
+[options.entry_points]
+console_scripts =
+    tiledb-cf = tiledb.cf:cli
 
 [flake8]
 ignore = E41,E203,E226,E302,E402,W503

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,8 @@ def simple1_netcdf_file(tmpdir_factory):
     filepath = str(tmpdir_factory.mktemp("sample_netcdf").join("simple1.nc"))
     with netCDF4.Dataset(filepath, mode="w") as dataset:
         dataset.createDimension("row", 8)
-        dataset.createVariable("x1", np.float64, ("row",))
+        x1 = dataset.createVariable("x1", np.float64, ("row",))
+        x1[:] = np.linspace(1.0, 4.0, 8)
     return filepath
 
 
@@ -30,8 +31,10 @@ def simple2_netcdf_file(tmpdir_factory):
     filepath = str(tmpdir_factory.mktemp("sample_netcdf").join("simple1.nc"))
     with netCDF4.Dataset(filepath, mode="w") as dataset:
         dataset.createDimension("row", 8)
-        dataset.createVariable("x1", np.float64, ("row",))
-        dataset.createVariable("x2", np.float64, ("row",))
+        x1 = dataset.createVariable("x1", np.float64, ("row",))
+        x1[:] = np.linspace(0.0, 1.0, 8)
+        x2 = dataset.createVariable("x2", np.float64, ("row",))
+        x2[:] = np.linspace(0.0, 1.0, 8) ** 2
     return filepath
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,51 @@ def simple2_netcdf_file(tmpdir_factory):
     return filepath
 
 
+@pytest.fixture(scope="session")
+def group1_netcdf_file(tmpdir_factory):
+    """Sample NetCDF file with groups
+
+    root:
+      dimensions:  row(8)
+      variables: x1(row) = np.linspace(-1.0, 1.0, 8)
+      group1:
+        variables: x2(row) = 2 * np.linspace(-1.0, 1.0, 8)
+        group2:
+          dimensions: col(4)
+          variables: y1(col) = np.linspace(-1.0, 1.0, 4)
+      group3:
+          dimensions: row(4), col(4)
+          variables:
+            A1[:, :] = np.outer(y1, y1)
+            A2[:, :] = np.zeros((4,4), dtype=np.float64)
+            A3[:, :] = np.identity(4)
+    """
+    filepath = str(tmpdir_factory.mktemp("sample_netcdf").join("simple1.nc"))
+    x = np.linspace(-1.0, 1.0, 8)
+    y = np.linspace(-1.0, 1.0, 4)
+    with netCDF4.Dataset(filepath, mode="w") as dataset:
+        dataset.createDimension("row", 8)
+        x1 = dataset.createVariable("x1", np.float64, ("row",))
+        x1[:] = x
+        group1 = dataset.createGroup("group1")
+        x2 = group1.createVariable("x2", np.float64, ("row",))
+        x2[:] = 2.0 * x
+        group2 = group1.createGroup("group2")
+        group2.createDimension("col", 4)
+        y1 = group2.createVariable("y1", np.float64, ("col",))
+        y1[:] = y
+        group3 = dataset.createGroup("group3")
+        group3.createDimension("row", 4)
+        group3.createDimension("col", 4)
+        A1 = group3.createVariable("A1", np.float64, ("row", "col"))
+        A2 = group3.createVariable("A2", np.float64, ("row", "col"))
+        A3 = group3.createVariable("A3", np.int32, ("row", "col"))
+        A1[:, :] = np.outer(y, y)
+        A2[:, :] = np.zeros((4, 4), dtype=np.float64)
+        A3[:, :] = np.identity(4)
+    return filepath
+
+
 @pytest.fixture(scope="function")
 def netcdf4_test_case(tmpdir_factory, request):
     """Creates a NetCDF file and returns the filepath stem, filepath, and dict of

--- a/tests/test_cli_netcdf_convert.py
+++ b/tests/test_cli_netcdf_convert.py
@@ -1,0 +1,23 @@
+import numpy as np
+from click.testing import CliRunner
+
+import tiledb
+import tiledb.cf
+
+
+def test_netcdf_convert(tmpdir, simple1_netcdf_file):
+    uri = str(tmpdir.mkdir("output").join("simple1"))
+    runner = CliRunner()
+    result = runner.invoke(
+        tiledb.cf.cli,
+        ["netcdf-convert", "-i", simple1_netcdf_file, "-o", uri],
+    )
+    assert result.exit_code == 0
+    array_schema = tiledb.ArraySchema.load(uri + "/array0")
+    attr_names = [attr.name for attr in array_schema]
+    dim_names = [dim.name for dim in array_schema.domain]
+    assert attr_names == ["x1"]
+    assert dim_names == ["row"]
+    with tiledb.open(uri + "/array0", attr="x1") as array:
+        x1 = array[:]
+    assert np.array_equal(x1, np.linspace(1.0, 4.0, 8))

--- a/tiledb/cf/__init__.py
+++ b/tiledb/cf/__init__.py
@@ -1,5 +1,10 @@
 # Copyright 2021 TileDB Inc.
 # Licensed under the MIT License.
+from typing import Dict, Optional, Tuple, Union
+
+import click
+import numpy as np
+
 from .core import (
     ATTR_METADATA_FLAG,
     METADATA_ARRAY_NAME,
@@ -10,3 +15,92 @@ from .core import (
 )
 from .creator import DATA_SUFFIX, INDEX_SUFFIX, DataspaceCreator, axis_name
 from .engines import from_netcdf, from_netcdf_group
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command("netcdf-convert")
+@click.option(
+    "-i",
+    "--input-file",
+    required=True,
+    type=str,
+    help="The path or URI to the NetCDF file that will be converted.",
+)
+@click.option(
+    "-o",
+    "--output-uri",
+    required=True,
+    type=str,
+    help="The URI for the output TileDB group.",
+)
+@click.option(
+    "--input-group-path",
+    type=str,
+    default="/",
+    show_default=True,
+    help="The path in the input NetCDF for the root group that will be converted.",
+)
+@click.option(
+    "--recursive/--no-recursive",
+    default=True,
+    show_default=True,
+    help="Recursively convert all groups contained in the input group path.",
+)
+@click.option(
+    "-k",
+    "--output-key",
+    type=str,
+    default=None,
+    show_default=True,
+    help="Key for the generated TileDB arrays.",
+)
+@click.option(
+    "--unlimited-dim-size",
+    type=int,
+    default=10000,
+    show_default=True,
+    help="Size to convert unlimited dimensions to.",
+)
+@click.option(
+    "--dim-dtype",
+    type=click.Choice(
+        [
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+        ]
+    ),
+    default="uint64",
+    show_default=True,
+    help="The data type for TileDB dimensions created from converted NetCDF.",
+)
+def netcdf_convert(
+    input_file: str,
+    output_uri: str,
+    input_group_path: str,
+    recursive: bool,
+    output_key: Optional[str],
+    unlimited_dim_size: int,
+    dim_dtype: str,
+):
+    """Converts a NetCDF input file to nested TileDB groups."""
+    from_netcdf(
+        input_file=input_file,
+        output_uri=output_uri,
+        input_group_path=input_group_path,
+        recursive=recursive,
+        output_key=output_key,
+        output_ctx=None,
+        unlimited_dim_size=unlimited_dim_size,
+        dim_dtype=np.dtype(dim_dtype),
+        tiles=None,
+    )

--- a/tiledb/cf/__init__.py
+++ b/tiledb/cf/__init__.py
@@ -9,4 +9,4 @@ from .core import (
     GroupSchema,
 )
 from .creator import DATA_SUFFIX, INDEX_SUFFIX, DataspaceCreator, axis_name
-from .engines import from_netcdf_file, from_netcdf_group
+from .engines import from_netcdf, from_netcdf_group

--- a/tiledb/cf/__main__.py
+++ b/tiledb/cf/__main__.py
@@ -1,0 +1,3 @@
+from tiledb.cf import cli
+
+cli()

--- a/tiledb/cf/engines/__init__.py
+++ b/tiledb/cf/engines/__init__.py
@@ -15,11 +15,11 @@ def from_netcdf(
     output_uri: str,
     input_group_path: str = "/",
     recursive: bool = True,
-    output_key: Optional[Union[Dict[str, str], str]] = None,
+    output_key: Optional[Union[str, Dict[str, str]]] = None,
     output_ctx: Optional[tiledb.Ctx] = None,
     unlimited_dim_size: int = 10000,
     dim_dtype: np.dtype = _DEFAULT_INDEX_DTYPE,
-    tiles: Dict[Tuple[str, ...], Tuple[int, ...]] = None,
+    tiles: Dict[str, Dict[Tuple[str, ...], Tuple[int, ...]]] = None,
 ):
     """Converts a NetCDF input file to nested TileDB CF dataspaces.
 
@@ -31,6 +31,8 @@ def from_netcdf(
         output_uri: Uniform resource identifier for the TileDB group to be created.
         input_group_path: The path to the NetCDF group to copy data from. Use ``'/'``
             for the root group.
+        recursive: If ``True``, recursively convert groups in a NetCDF file. Otherwise,
+            only convert group provided.
         output_key: If not ``None``, encryption key, or dictionary of encryption keys,
             to decrypt arrays.
         output_ctx: If not ``None``, TileDB context wrapper for a TileDB storage
@@ -39,8 +41,9 @@ def from_netcdf(
         unlimited_dim_size: The size of the domain for TileDB dimensions created
             from unlimited NetCDF dimensions.
         dim_dtype: The numpy dtype for TileDB dimensions.
-        tiles: A map from the name of NetCDF dimensions defining a variable to the
-            tiles of those dimensions in the generated NetCDF array.
+        tiles: A map from the NetCDF group name to a map from the name of NetCDF
+            dimensions defining a variable to the tiles of those dimensions in the
+            generated NetCDF array.
     """
     from .netcdf4_engine import NetCDF4ConverterEngine, open_netcdf_group
 
@@ -54,7 +57,7 @@ def from_netcdf(
             dim_dtype,
             tiles.get(group.path) if tiles is not None else None,
         )
-        converter.convert(group_uri, output_key, output_ctx, netcdf_group=dataset)
+        converter.convert(group_uri, output_key, output_ctx, netcdf_group=group)
         if recursive:
             for subgroup in group.groups.values():
                 recursive_convert_group(subgroup)

--- a/tiledb/cf/engines/__init__.py
+++ b/tiledb/cf/engines/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2021 TileDB Inc.
 # Licensed under the MIT License.
+from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
@@ -10,7 +11,7 @@ _DEFAULT_INDEX_DTYPE = np.dtype("uint64")
 
 
 def from_netcdf(
-    input_file: str,
+    input_file: Union[str, Path],
     output_uri: str,
     input_group_path: str = "/",
     recursive: bool = True,
@@ -82,8 +83,8 @@ def from_netcdf_group(
     information on the backend converter engine used for the conversion.
 
     Parameters:
-        netcdf_input (Union[str, netCDF4.Dataset, netCDF4.Group]): Either the NetCDF
-            group to convert or the filepath (as a string) to the NetCDF group.
+        netcdf_input (Union[str, Path, netCDF4.Dataset, netCDF4.Group]): Either the
+            NetCDF group to convert or the filepath (as a string) to the NetCDF group.
         output_uri: Uniform resource identifier for the TileDB group to be created.
         input_group_path: The path to the NetCDF group to copy data from. Use ``'/'``
             for the root group. This is only used if ``netcdf_input`` is a filepath.
@@ -99,7 +100,7 @@ def from_netcdf_group(
     """
     from .netcdf4_engine import NetCDF4ConverterEngine
 
-    if isinstance(netcdf_input, str):
+    if isinstance(netcdf_input, (str, Path)):
         converter = NetCDF4ConverterEngine.from_file(
             netcdf_input,
             input_group_path,

--- a/tiledb/cf/engines/__init__.py
+++ b/tiledb/cf/engines/__init__.py
@@ -9,17 +9,18 @@ import tiledb
 _DEFAULT_INDEX_DTYPE = np.dtype("uint64")
 
 
-def from_netcdf_file(
+def from_netcdf(
     input_file: str,
     output_uri: str,
     input_group_path: str = "/",
+    recursive: bool = True,
     output_key: Optional[Union[Dict[str, str], str]] = None,
     output_ctx: Optional[tiledb.Ctx] = None,
     unlimited_dim_size: int = 10000,
     dim_dtype: np.dtype = _DEFAULT_INDEX_DTYPE,
     tiles: Dict[Tuple[str, ...], Tuple[int, ...]] = None,
 ):
-    """Converts a NetCDF group from a provided input file to a TileDB CF dataspace.
+    """Converts a NetCDF input file to nested TileDB CF dataspaces.
 
     See :class:`~tiledb.cf.engines.netcdf4_engine.NetCDF4ConverterEngine` for more
     information on the backend converter engine used for the conversion.
@@ -40,36 +41,52 @@ def from_netcdf_file(
         tiles: A map from the name of NetCDF dimensions defining a variable to the
             tiles of those dimensions in the generated NetCDF array.
     """
-    from .netcdf4_engine import NetCDF4ConverterEngine
+    from .netcdf4_engine import NetCDF4ConverterEngine, open_netcdf_group
 
-    converter = NetCDF4ConverterEngine.from_file(
-        input_file,
-        input_group_path,
-        unlimited_dim_size,
-        dim_dtype,
-        tiles,
-    )
-    converter.convert(output_uri, output_key, output_ctx)
+    output_uri = output_uri if not output_uri.endswith("/") else output_uri[:-1]
+
+    def recursive_convert_group(group):
+        group_uri = output_uri + group.path
+        converter = NetCDF4ConverterEngine.from_group(
+            group,
+            unlimited_dim_size,
+            dim_dtype,
+            tiles.get(group.path) if tiles is not None else None,
+        )
+        converter.convert(group_uri, output_key, output_ctx, netcdf_group=dataset)
+        if recursive:
+            for subgroup in group.groups.values():
+                recursive_convert_group(subgroup)
+
+    with open_netcdf_group(
+        input_file=input_file,
+        group_path=input_group_path,
+    ) as dataset:
+        recursive_convert_group(dataset)
 
 
 def from_netcdf_group(
-    input_group,
+    netcdf_input,
     output_uri: str,
+    input_group_path: str = "/",
     output_key: Optional[Union[Dict[str, str], str]] = None,
     output_ctx: Optional[tiledb.Ctx] = None,
     unlimited_dim_size: int = 10000,
     dim_dtype: np.dtype = _DEFAULT_INDEX_DTYPE,
     tiles: Dict[Tuple[str, ...], Tuple[int, ...]] = None,
 ):
-    """Converts a :class:`netCDF4.Group` to a TileDB CF dataspace.
+    """Converts a group in a NetCDF file or :class:`netCDF4.Group` to a TileDB CF
+    dataspace.
 
     See :class:`~tiledb.cf.engines.netcdf4_engine.NetCDF4ConverterEngine` for more
     information on the backend converter engine used for the conversion.
 
     Parameters:
-        input_group (netCDF4.Group): The NetCDF group to generate the converter engine
-            from.
+        netcdf_input (Union[str, netCDF4.Dataset, netCDF4.Group]): Either the NetCDF
+            group to convert or the filepath (as a string) to the NetCDF group.
         output_uri: Uniform resource identifier for the TileDB group to be created.
+        input_group_path: The path to the NetCDF group to copy data from. Use ``'/'``
+            for the root group. This is only used if ``netcdf_input`` is a filepath.
         output_key: If not ``None``, encryption key, or dictionary of encryption keys,
             to decrypt arrays.
         output_ctx: If not ``None``, TileDB context wrapper for a TileDB storage
@@ -82,10 +99,20 @@ def from_netcdf_group(
     """
     from .netcdf4_engine import NetCDF4ConverterEngine
 
-    converter = NetCDF4ConverterEngine.from_group(
-        input_group,
-        unlimited_dim_size,
-        dim_dtype,
-        tiles,
-    )
-    converter.convert(output_uri, output_key, output_ctx, netcdf_group=input_group)
+    if isinstance(netcdf_input, str):
+        converter = NetCDF4ConverterEngine.from_file(
+            netcdf_input,
+            input_group_path,
+            unlimited_dim_size,
+            dim_dtype,
+            tiles,
+        )
+        converter.convert(output_uri, output_key, output_ctx)
+    else:
+        converter = NetCDF4ConverterEngine.from_group(
+            netcdf_input,
+            unlimited_dim_size,
+            dim_dtype,
+            tiles,
+        )
+        converter.convert(output_uri, output_key, output_ctx, netcdf_group=netcdf_input)

--- a/tiledb/cf/engines/netcdf4_engine.py
+++ b/tiledb/cf/engines/netcdf4_engine.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from io import StringIO
+from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import netCDF4
@@ -210,7 +211,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
     @classmethod
     def from_file(
         cls,
-        input_file: str,
+        input_file: Union[str, Path],
         group_path: str = "/",
         unlimited_dim_size: int = 10000,
         dim_dtype: np.dtype = _DEFAULT_INDEX_DTYPE,
@@ -248,7 +249,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
         unlimited_dim_size: int = 10000,
         dim_dtype: np.dtype = _DEFAULT_INDEX_DTYPE,
         tiles: Dict[Tuple[str, ...], Tuple[int, ...]] = None,
-        default_input_file: Optional[str] = None,
+        default_input_file: Optional[Union[str, Path]] = None,
         default_group_path: Optional[str] = None,
     ):
         """Returns a :class:`NetCDF4ConverterEngine` from a `class`:netCDF4.Group`.
@@ -302,7 +303,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
         dimensions: Dict[str, NetCDFDimensionConverter],
         variables: Dict[str, NetCDFVariableConverter],
         arrays: Dict[str, NetCDFArrayConverter],
-        default_input_file: Optional[str] = None,
+        default_input_file: Optional[Union[str, Path]] = None,
         default_group_path: Optional[str] = None,
     ):
         self._dimensions = dimensions
@@ -389,7 +390,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
         key: Optional[Union[Dict[str, str], str]] = None,
         ctx: Optional[tiledb.Ctx] = None,
         netcdf_group: Optional[netCDF4.Group] = None,
-        input_file: Optional[str] = None,
+        input_file: Optional[Union[str, Path]] = None,
         group_path: Optional[str] = None,
     ):
         """Creates a TileDB group and its arrays from the defined CF dataspace and
@@ -411,7 +412,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
         key: Optional[Union[Dict[str, str], str]] = None,
         ctx: Optional[tiledb.Ctx] = None,
         netcdf_group: Optional[netCDF4.Group] = None,
-        input_file: Optional[str] = None,
+        input_file: Optional[Union[str, Path]] = None,
         group_path: Optional[str] = None,
     ):
         """Copies data from a NetCDF group to a TileDB CF dataspace.
@@ -538,7 +539,7 @@ def copy_metadata_item(meta, netcdf_item, key):
 @contextmanager
 def open_netcdf_group(
     group: Optional[Union[netCDF4.Dataset, netCDF4.Group]] = None,
-    input_file: Optional[str] = None,
+    input_file: Optional[Union[str, Path]] = None,
     group_path: Optional[str] = None,
 ):
     """Context manager for opening a NetCDF group.


### PR DESCRIPTION
features:
* Create a top level CLI tool `tiledb-cf`
* Create a `netcdf-convert` command for `tiledb-cf` that wraps `from_netcdf` 

changes:
* Update functions `from_netcdf` (renamed from `from_netcdf_file`) to recursive convert an entire NetCDF file
* Update `from_netcdf_group` to convert groups from a netCDF4.Group or filename and group path