### PR TITLE
Update DataspaceCreator to match CF specification

### DIFF
--- a/tests/test_converter_netcdf4_engine.py
+++ b/tests/test_converter_netcdf4_engine.py
@@ -62,7 +62,7 @@ scalar_variables = NetCDF4TestCase(
 
 
 attr_to_var_map = {
-    "simple_coord_1": {"data": "data", "x": "x", "y": "y", "row.axis_data": "row"},
+    "simple_coord_1": {"data": "data", "x": "x", "y": "y", "row.data": "row"},
     "simple_unlim_dim": {"data": "data", "x": "x", "y": "y"},
     "scalar_variables": {"x": "x", "y": "y"},
 }

--- a/tests/test_dataspace_creator.py
+++ b/tests/test_dataspace_creator.py
@@ -11,9 +11,9 @@ class TestDataspaceCreatorExample1:
     @pytest.fixture
     def dataspace_creator(self):
         creator = DataspaceCreator()
-        creator.add_dim("pressure.axis_index", (0, 3), np.uint64)
+        creator.add_dim("pressure.index", (0, 3), np.uint64)
         creator.add_dim("temperature", (1, 8), np.uint64)
-        creator.add_array("A1", ("pressure.axis_index",))
+        creator.add_array("A1", ("pressure.index",))
         filters = tiledb.FilterList(
             [
                 tiledb.ZstdFilter(level=1),
@@ -21,7 +21,7 @@ class TestDataspaceCreatorExample1:
         )
         creator.add_array(
             "A2",
-            ("pressure.axis_index", "temperature"),
+            ("pressure.index", "temperature"),
             sparse=True,
             dim_filters={"temperature": filters},
         )
@@ -29,7 +29,7 @@ class TestDataspaceCreatorExample1:
         creator.set_array_properties("A1", tiles=(2,))
         creator.set_array_properties("A2", tiles=(2, 4))
         creator.set_array_properties("A3", tiles=[8])
-        creator.add_attr("pressure.axis_data", "A1", np.float64)
+        creator.add_attr("pressure.data", "A1", np.float64)
         creator.add_attr("b", "A1", np.float64)
         creator.add_attr("c", "A1", np.uint64)
         creator.add_attr("d", "A2", np.uint64)
@@ -44,7 +44,7 @@ class TestDataspaceCreatorExample1:
 
     def test_attr_names(self, dataspace_creator):
         assert set(dataspace_creator.attr_names) == {
-            "pressure.axis_data",
+            "pressure.data",
             "b",
             "c",
             "d",
@@ -53,7 +53,7 @@ class TestDataspaceCreatorExample1:
 
     def test_dim_names(self, dataspace_creator):
         assert set(dataspace_creator.dim_names) == {
-            "pressure.axis_index",
+            "pressure.index",
             "temperature",
         }
 
@@ -64,11 +64,11 @@ class TestDataspaceCreatorExample1:
         assert group_schema["A1"] == tiledb.ArraySchema(
             domain=tiledb.Domain(
                 tiledb.Dim(
-                    name="pressure.axis_index", domain=(0, 3), tile=2, dtype=np.uint64
+                    name="pressure.index", domain=(0, 3), tile=2, dtype=np.uint64
                 )
             ),
             attrs=[
-                tiledb.Attr(name="pressure.axis_data", dtype=np.float64),
+                tiledb.Attr(name="pressure.data", dtype=np.float64),
                 tiledb.Attr(name="b", dtype=np.float64),
                 tiledb.Attr(name="c", dtype=np.uint64),
             ],
@@ -76,7 +76,7 @@ class TestDataspaceCreatorExample1:
         assert group_schema["A2"] == tiledb.ArraySchema(
             domain=tiledb.Domain(
                 tiledb.Dim(
-                    name="pressure.axis_index", domain=(0, 3), tile=2, dtype=np.uint64
+                    name="pressure.index", domain=(0, 3), tile=2, dtype=np.uint64
                 ),
                 tiledb.Dim(
                     name="temperature",
@@ -184,12 +184,12 @@ def test_add_attr_axis_data_coord_exists_error():
     creator.add_array("array2", list())
     creator.add_attr("attr1", "array1", np.float64)
     with pytest.raises(ValueError):
-        creator.add_attr("attr1.axis_data", "array2", np.float64)
+        creator.add_attr("attr1.data", "array2", np.float64)
 
 
 def test_add_attr_index_axis_coord_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("coord.axis_index", (1, 4), np.uint64)
+    creator.add_dim("coord.index", (1, 4), np.uint64)
     creator.add_dim("row", (0, 3), np.int64)
     creator.add_array(
         "array1",
@@ -198,7 +198,7 @@ def test_add_attr_index_axis_coord_exists_error():
         ],
     )
     with pytest.raises(NotImplementedError):
-        creator.add_attr("coord.axis_data", "array1", np.float64)
+        creator.add_attr("coord.data", "array1", np.float64)
 
 
 def test_add_dim_name_exists_error():
@@ -212,7 +212,7 @@ def test_add_dim_index_dataspace_name_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", (0, 3), np.uint64)
     with pytest.raises(ValueError):
-        creator.add_dim("row.axis_index", (0, 7), np.uint64)
+        creator.add_dim("row.index", (0, 7), np.uint64)
 
 
 def test_add_dim_attr_coord_name_exists_error():
@@ -231,7 +231,7 @@ def test_add_dim_attr_coord_name_exists_error():
 
 def test_add_dim_coord_axis_index_name_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("pressure.axis_index", (1, 4), np.uint64)
+    creator.add_dim("pressure.index", (1, 4), np.uint64)
     with pytest.raises(ValueError):
         creator.add_dim("pressure", (0.0, 100.0), np.float64)
 
@@ -240,9 +240,9 @@ def test_add_dim_coord_axis_data_name_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", (0, 3), np.int64)
     creator.add_array("array1", ["row"])
-    creator.add_attr("coord.axis_index", "array1", np.float64)
+    creator.add_attr("coord.index", "array1", np.float64)
     with pytest.raises(NotImplementedError):
-        creator.add_dim("coord.axis_data", (1, 4), np.uint64)
+        creator.add_dim("coord.data", (1, 4), np.uint64)
 
 
 def test_remove_empty_array():
@@ -309,19 +309,19 @@ def test_remove_dim():
 
 def test_remove_dim_axis_data():
     creator = DataspaceCreator()
-    creator.add_dim("row.axis_data", [0.0, 100.0], np.float64)
-    assert set(creator.dim_names) == {"row.axis_data"}
-    creator.remove_dim("row.axis_data")
+    creator.add_dim("row.data", [0.0, 100.0], np.float64)
+    assert set(creator.dim_names) == {"row.data"}
+    creator.remove_dim("row.data")
     assert set(creator.dim_names) == set()
 
 
 def test_remove_dim_in_use_error():
     creator = DataspaceCreator()
-    creator.add_dim("row.axis_data", [0.0, 100.0], np.float64)
-    creator.add_array("A1", ["row.axis_data"], sparse=True)
-    creator.add_array("A2", ["row.axis_data"], sparse=True)
+    creator.add_dim("row.data", [0.0, 100.0], np.float64)
+    creator.add_array("A1", ["row.data"], sparse=True)
+    creator.add_array("A2", ["row.data"], sparse=True)
     with pytest.raises(ValueError):
-        creator.remove_dim("row.axis_data")
+        creator.remove_dim("row.data")
 
 
 def test_rename_array():

--- a/tests/test_dataspace_creator.py
+++ b/tests/test_dataspace_creator.py
@@ -57,8 +57,8 @@ class TestDataspaceCreatorExample1:
             "temperature",
         }
 
-    def test_data_axis_names(self, dataspace_creator):
-        assert set(dataspace_creator.data_axis_names) == {"temperature"}
+    def test_data_dim_names(self, dataspace_creator):
+        assert set(dataspace_creator.data_dim_names) == {"temperature"}
 
     def test_to_schema(self, dataspace_creator):
         group_schema = dataspace_creator.to_schema()
@@ -307,10 +307,10 @@ def test_remove_dim_axis_data():
     creator = DataspaceCreator()
     creator.add_dim("row.axis_data", [0.0, 100.0], np.float64)
     assert set(creator.dim_names) == {"row.axis_data"}
-    assert set(creator.data_axis_names) == {"row"}
+    assert set(creator.data_dim_names) == {"row"}
     creator.remove_dim("row.axis_data")
     assert set(creator.dim_names) == set()
-    assert set(creator.data_axis_names) == set()
+    assert set(creator.data_dim_names) == set()
 
 
 def test_remove_dim_in_use_error():
@@ -402,10 +402,10 @@ def test_rename_dim_dataspace_axis():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 3], np.float64)
     assert set(creator.dim_names) == {"row"}
-    assert set(creator.data_axis_names) == {"row"}
+    assert set(creator.data_dim_names) == {"row"}
     creator.rename_dim("row", "col")
     assert set(creator.dim_names) == {"col"}
-    assert set(creator.data_axis_names) == {"col"}
+    assert set(creator.data_dim_names) == {"col"}
 
 
 def test_rename_dim_used():

--- a/tests/test_dataspace_creator.py
+++ b/tests/test_dataspace_creator.py
@@ -57,9 +57,6 @@ class TestDataspaceCreatorExample1:
             "temperature",
         }
 
-    def test_data_dim_names(self, dataspace_creator):
-        assert set(dataspace_creator.data_dim_names) == {"temperature"}
-
     def test_to_schema(self, dataspace_creator):
         group_schema = dataspace_creator.to_schema()
         assert isinstance(group_schema, GroupSchema)
@@ -307,10 +304,8 @@ def test_remove_dim_axis_data():
     creator = DataspaceCreator()
     creator.add_dim("row.axis_data", [0.0, 100.0], np.float64)
     assert set(creator.dim_names) == {"row.axis_data"}
-    assert set(creator.data_dim_names) == {"row"}
     creator.remove_dim("row.axis_data")
     assert set(creator.dim_names) == set()
-    assert set(creator.data_dim_names) == set()
 
 
 def test_remove_dim_in_use_error():
@@ -402,10 +397,8 @@ def test_rename_dim_dataspace_axis():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 3], np.float64)
     assert set(creator.dim_names) == {"row"}
-    assert set(creator.data_dim_names) == {"row"}
     creator.rename_dim("row", "col")
     assert set(creator.dim_names) == {"col"}
-    assert set(creator.data_dim_names) == {"col"}
 
 
 def test_rename_dim_used():

--- a/tests/test_dataspace_creator.py
+++ b/tests/test_dataspace_creator.py
@@ -155,7 +155,7 @@ def test_add_attr_dim_coord_name_exists_error():
             "row",
         ],
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         creator.add_attr("coord", "array1", np.float64)
 
 
@@ -197,7 +197,7 @@ def test_add_attr_index_axis_coord_exists_error():
             "row",
         ],
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         creator.add_attr("coord.axis_data", "array1", np.float64)
 
 
@@ -206,6 +206,13 @@ def test_add_dim_name_exists_error():
     creator.add_dim("row", (1, 4), np.uint64)
     with pytest.raises(ValueError):
         creator.add_dim("row", (0, 3), np.int64)
+
+
+def test_add_dim_index_dataspace_name_exists_error():
+    creator = DataspaceCreator()
+    creator.add_dim("row", (0, 3), np.uint64)
+    with pytest.raises(ValueError):
+        creator.add_dim("row.axis_index", (0, 7), np.uint64)
 
 
 def test_add_dim_attr_coord_name_exists_error():
@@ -218,7 +225,7 @@ def test_add_dim_attr_coord_name_exists_error():
         ],
     )
     creator.add_attr("coord", "array1", np.float64)
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         creator.add_dim("coord", (1, 4), np.uint64)
 
 
@@ -234,7 +241,7 @@ def test_add_dim_coord_axis_data_name_exists_error():
     creator.add_dim("row", (0, 3), np.int64)
     creator.add_array("array1", ["row"])
     creator.add_attr("coord.axis_index", "array1", np.float64)
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         creator.add_dim("coord.axis_data", (1, 4), np.uint64)
 
 

--- a/tiledb-cf-spec.md
+++ b/tiledb-cf-spec.md
@@ -35,23 +35,26 @@ A TileDB CF dataspace is a TileDB group with arrays, attributes, and dimensions 
 
 ### Terminology
 
+* **Dataspace name**: The name of an attribute or dimension stripped of an optional suffix of `.index` or `.data`.
 * **Index dimension**: A TileDB dimension with an integer data type and domain with `0` as its lower bound.
 * **Data dimension**: Any TileDB dimension that is not an index dimension.
-* **Dataspace name**: The name of an attribute or dimension stripped of an optional suffix of `.index` or `.data`.
+* **Collection of dimensions**: A set of TileDB dimensions with the same name, data type, and domain.
 
 ### CF Dataspace
+
+A CF Dataspace is a TileDB group that follows certain requirements in order to provide additional relational context to dimensions and attributes using naming conventions. In a CF Dataspace, attributes within the entire group are unique; an index dimension that shares that same dataspace name as an attribute is an indexer for that attribute; and a data dimension that shares the same name as an attribute is a reference to the same data.
 
 #### Requirements for Attributes and Dimensions
 
 1. All attributes and dimension must be named (there must not be any anonymous attributes or dimensions).
-2. All dimensions that share a name must have the same domain and data type.
-3. All attributes must have a unique dataspace name.
-4. If an attribute and data dimension share the same dataspace name, they must share the same full name and data type.
+2. All dimensions that share a name must belong to the same collection (they must have the same domain and data type), and for any given dataspace name there may be at most one collection of index dimensions and one collection of data dimensions with that dataspace name.
+4. All attributes must have a unique dataspace name.
+5. If an attribute and data dimension share the same dataspace name, they must share the same full name and data type.
 
 #### Requirements for Metadata
 
 1. Group metadata is stored in a special metadata array named `__tiledb_group` inside the TileDB group.
-2. Attribute metadata is stored in the array the attribute is in using the prefix `__tiledb_attr.{attr_name}.` for the attribute key where `{attr_name}` is the full name of the attribute.
+2. Attribute metadata is stored in the same array the attribute is stored in. The metadata key must use the prefix `__tiledb_attr.{attr_name}.` where `{attr_name}` is the full name of the attribute.
 3. If the metadata key `_FillValue` exists for an attribute; it must have the same value as the fill value for the attribute.
 
 ### Indexable CF Dataspace
@@ -95,6 +98,6 @@ This is a suggestion on how to convert a collection of indexable TileDB CF datas
 
 The TileDB CF Dataspace fully supports the classic NetCDF Data Model and most features in the NetCDF-4 data model. Some features and use cases do not directly transfer or may need to be modified before use in TileDB.
 
-* **Unlimited Dimensions**: TileDB can support unlimited dimensions by using fill values, sparse arrays, or nullable attributes. However, for dataset consisting of multiple attributes stored in multiple arrays, it may be difficult to determine the current size of the unlimited dimension.
 * **Coordinates**: In NetCDF, it is a common convention to name a one-dimensional variable with the same name as its dimension to signify it as a "coordinate" or independent variable other variables are defined on. In TileDB, a variable and dimension in the same array cannot have the same name. This is handled by using the `.index` and `.data` suffixes.
+* **Unlimited Dimensions**: TileDB can support unlimited dimensions by using fill values, sparse arrays, or nullable attributes. However, for dataset consisting of multiple attributes stored in multiple arrays, it may be cumbersome to determine the current "size" (maximum coordinate data has been added for) of the unlimited dimension. Storing attributes defined on the same dimensions in the same array helps partially mitigate this issue.
 * **Compound data types**: As of TileDB version 2.2, compound data types are not directly supported in TileDB. Compound data types can be broken into their constituent parts; however, this breaks storage locality (TileDB attributes are stored in a [columnar format](https://docs.tiledb.com/main/basic-concepts/data-format)). Variable, opaque, and string data types are supported.

--- a/tiledb-cf-spec.md
+++ b/tiledb-cf-spec.md
@@ -49,7 +49,7 @@ A CF Dataspace is a TileDB group that follows certain requirements in order to p
 1. All attributes and dimension must be named (there must not be any anonymous attributes or dimensions).
 2. All dimensions that share a name must belong to the same collection (they must have the same domain and data type), and for any given dataspace name there may be at most one collection of index dimensions and one collection of data dimensions with that dataspace name.
 4. All attributes must have a unique dataspace name.
-5. If an attribute and data dimension share the same dataspace name, they must share the same full name and data type.
+5. If an attribute and data dimension share the same dataspace name, they must share the same full name, data type, and variability. The attribute must have only 1 cell.
 
 #### Requirements for Metadata
 

--- a/tiledb/cf/__init__.py
+++ b/tiledb/cf/__init__.py
@@ -13,7 +13,7 @@ from .core import (
     Group,
     GroupSchema,
 )
-from .creator import DATA_SUFFIX, INDEX_SUFFIX, DataspaceCreator, axis_name
+from .creator import DATA_SUFFIX, INDEX_SUFFIX, DataspaceCreator, dataspace_name
 from .engines import from_netcdf, from_netcdf_group
 
 

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -318,20 +318,6 @@ class DataspaceCreator:
         Group.create(group_uri, self.to_schema(ctx), key, ctx)
 
     @property
-    def data_dim_names(self):
-        """A view of the 'axis names' of dimensions in the dataspace that are data
-        axes.
-
-        A data axis or data dimension is a dimension that is not an integer dimension or
-        is an integer dimension whose domain starts at a value other than 0. This is in
-        contrast to 'index dimensions', a dimension that is a simple index.
-
-        The axis name is the name of the dimension after dropping the optional suffixes
-        `.data_axis` or `.data_index`.
-        """
-        return self._data_dim_names.keys()
-
-    @property
     def dim_names(self):
         """A view of the names of dimensions in the CF dataspace."""
         return self._dims.keys()

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -28,19 +28,20 @@ import tiledb
 from .core import METADATA_ARRAY_NAME, Group, GroupSchema
 
 DType = TypeVar("DType", covariant=True)
-DATA_SUFFIX = ".axis_data"
-INDEX_SUFFIX = ".axis_index"
+DATA_SUFFIX = ".data"
+INDEX_SUFFIX = ".index"
 
 
 def dataspace_name(full_name: str):
-    """Returns axis name for from full dimension or attribute name.
+    """Returns dataspace name for from full dimension or attribute name.
 
     Parameters:
         full_name: The full name of the dimension or attribute as it will be written in
             TileDB.
 
     Returns:
-        The name of the axis as it would be written in the NetCDF data model.
+        The name of the dimension or attribute as it would be written in the NetCDF data
+        model.
     """
     if full_name.endswith(DATA_SUFFIX):
         return full_name[: -len(DATA_SUFFIX)]
@@ -238,8 +239,8 @@ class DataspaceCreator:
 
         Each attribute name must be unique. It also cannot conflict with the name of a
         dimension in the array it is being added to, and the attribute's
-        'dataspace name' (name after dropping the suffix ``.axis_data`` or
-        ``.axis_index``) cannot conflict with the axis name of an existing attribute.
+        'dataspace name' (name after dropping the suffix ``.data`` or ``.index``) cannot
+        conflict with the dataspace name of an existing attribute.
 
         Parameters:
             attr_name: Name of the new attribute that will be added.
@@ -978,7 +979,7 @@ class SharedDim(Generic[DType]):
 
     @classmethod
     def from_tiledb_dim(cls, dim: tiledb.Dim):
-        """Converts a tiledb.Dim to a SharedDim
+        """Converts a tiledb.Dim to a :class:`SharedDim`
 
         Parameters:
             dim: TileDB dimension that will be used to create the shared
@@ -997,10 +998,19 @@ class SharedDim(Generic[DType]):
 
     @property
     def is_data_dim(self) -> bool:
-        """Returns if the currend SharedDimension is a 'data axis'
+        """Returns if the :class:`SharedDim` is a 'data dimension'
 
-        A data axis is a dimension that is not an integer type or starts at a value
+        A data dimension is a dimension that is not an integer type or starts at a value
         other than zero. This is compared to an 'index axis' that is a simple integer
         index with default offset.
         """
-        return not (np.issubdtype(self.dtype, np.integer) and self.domain[0] == 0)
+        return not self.is_index_dim
+
+    @property
+    def is_index_dim(self) -> bool:
+        """Returns if the :class:`SharedDim` is a 'index dimension'
+
+        An index dimension is a dimension that is of an integer type and whose domain
+        starts at 0.
+        """
+        return np.issubdtype(self.dtype, np.integer) and self.domain[0] == 0

--- a/tiledb/cf/engines/netcdf4_engine.py
+++ b/tiledb/cf/engines/netcdf4_engine.py
@@ -19,7 +19,7 @@ from ..core import Group
 from ..creator import DataspaceCreator
 
 _DEFAULT_INDEX_DTYPE = np.dtype("uint64")
-COORDINATE_SUFFIX = ".axis_data"
+COORDINATE_SUFFIX = ".data"
 
 
 @dataclass


### PR DESCRIPTION
docs:

* Update CF specification to add definition of a collection of dimensions, rules for name collisions on collections of dataspaces, and add additional context/clarity.

changes:

* Update checks for new attr and dim names to match specification document.
* Rename `axis_name` to `dataspace_name`.
* Rename `is_data_axis` to `is_data_dim`.
* Change `INDEX_SUFFIX` from `.axis_index` to `.index`.
* Change `DATA_SUFFIX` from `.axis_data` to `.data`.
*  Remove property `data_axis_names` from `DataspaceCreator`.