### PR TITLE
Add support for "virtual" groups

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,8 +46,10 @@ NetCDF4ConverterEngine
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: tiledb.cf.engines.netcdf4_engine.NetCDF4ConverterEngine
-   :members: from_file, from_group, copy
+   :members:
+   :inherited-members:
    :noindex:
+
 
 Core Classes
 ------------
@@ -57,6 +59,14 @@ Group
 
 .. autoclass:: tiledb.cf.Group
    :members:
+   :noindex:
+
+VirtualGroup
+^^^^^^^^^^^^
+
+.. autoclass:: tiledb.cf.VirtualGroup
+   :members:
+   :inherited-members:
    :noindex:
 
 

--- a/examples/create_groups.ipynb
+++ b/examples/create_groups.ipynb
@@ -1,0 +1,149 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python390jvsc74a57bd0f83ddd6991e62697b8e1c78d35b449f256fb868317b9158045034ef8d7136941",
+   "display_name": "Python 3.9.0 64-bit ('cf-3.9.0': pyenv)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tiledb\n",
+    "from tiledb.cf import Group, GroupSchema, VirtualGroup\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a TileDB-CF GroupSchema\n",
+    "row = tiledb.Dim(name=\"rows\", domain=(1, 4), tile=4, dtype=np.uint64)\n",
+    "col = tiledb.Dim(name=\"cols\", domain=(1, 8), tile=8, dtype=np.uint64)\n",
+    "group_schema = GroupSchema(\n",
+    "    {\n",
+    "        \"matrices\": tiledb.ArraySchema(\n",
+    "            domain=tiledb.Domain(row, col), \n",
+    "            attrs=[\n",
+    "                tiledb.Attr(name=\"A1\", dtype=np.float64), \n",
+    "                tiledb.Attr(name=\"A2\", dtype=np.float64), \n",
+    "                tiledb.Attr(name=\"A3\", dtype=np.float64),\n",
+    "            ],\n",
+    "        ),\n",
+    "        \"row_vectors\": tiledb.ArraySchema(\n",
+    "            domain=tiledb.Domain(row), \n",
+    "            attrs=[\n",
+    "                tiledb.Attr(name=\"y1\", dtype=np.float64), \n",
+    "                tiledb.Attr(name=\"y2\", dtype=np.float64),                \n",
+    "            ],\n",
+    "        ),\n",
+    "        \"column_vectors\": tiledb.ArraySchema(\n",
+    "            domain=tiledb.Domain(col), \n",
+    "            attrs=[\n",
+    "                tiledb.Attr(name=\"x1\", dtype=np.float64), \n",
+    "                tiledb.Attr(name=\"x2\", dtype=np.float64), \n",
+    "            ],\n",
+    "        ),\n",
+    "    }\n",
+    ")\n",
+    "group_schema.set_default_metadata_schema()\n",
+    "group_schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a TileDB-CF Group\n",
+    "uri1 = \"output/create_groups/example1\"\n",
+    "uri2 = \"output/create_groups/example2\"\n",
+    "create_group = False\n",
+    "create_virtual_group = False\n",
+    "if create_group:\n",
+    "    Group.create(uri1, group_schema)\n",
+    "if create_virtual_group:\n",
+    "    Group.create(uri2, group_schema, is_virtual=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check Example1 was created and try reading/writing\n",
+    "example1_schema = GroupSchema.load(uri1)\n",
+    "print(f\"Schema is correct: {example1_schema == group_schema}\")\n",
+    "with Group(uri1, attr=\"x1\", mode=\"w\") as group:\n",
+    "    group.array[:] = np.linspace(0.0, 1.0, 8)\n",
+    "    group.meta[\"dataset_name\"] = \"Example group dataset\"\n",
+    "with Group(uri1) as group:\n",
+    "    print(f\"Dataset name: {group.meta['dataset_name']}\")\n",
+    "with Group(uri1, array=\"column_vectors\") as group:\n",
+    "    data = group.array[:]\n",
+    "    print(\"Column vectors:\")\n",
+    "    for attr_name, attr_data in data.items():\n",
+    "        print(f\"  {attr_name}: {attr_data}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check Example2 was created and try reading/writing\n",
+    "#  * Since Example2 is a virtual group, we must create a dictionary\n",
+    "#    to the array URIs.\n",
+    "array_uris = {\n",
+    "    \"__tiledb_group\": uri2,\n",
+    "    \"column_vectors\": f\"{uri2}_column_vectors\",\n",
+    "    \"row_vectors\": f\"{uri2}_row_vectors\",\n",
+    "    \"matrices\": f\"{uri2}_matrices\",\n",
+    "}\n",
+    "example2_schema = GroupSchema.load_virtual(array_uris)\n",
+    "print(f\"Schema is correct: {example2_schema == group_schema}\") \n",
+    "with VirtualGroup(array_uris, attr=\"x1\", mode=\"w\") as group:\n",
+    "    group.array[:] = np.linspace(0.0, 1.0, 8)\n",
+    "    group.meta[\"dataset_name\"] = \"Example group dataset\"\n",
+    "with VirtualGroup(array_uris) as group:\n",
+    "    print(f\"Dataset name: {group.meta['dataset_name']}\")\n",
+    "with VirtualGroup(array_uris, array=\"column_vectors\") as group:\n",
+    "    data = group.array[:]\n",
+    "    print(\"Column vectors:\")\n",
+    "    for attr_name, attr_data in data.items():\n",
+    "        print(f\"  {attr_name}: {attr_data}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/tests/core/test_group.py
+++ b/tests/core/test_group.py
@@ -54,6 +54,32 @@ class TestCreateGroup:
             assert tiledb.ArraySchema.load(array_uri, key=self._key) == schema
 
 
+class TestCreateVirtualGroup:
+
+    _metadata_schema = _array_schema_1
+    _array_schemas = [
+        ("A1", _array_schema_1),
+        ("A2", _array_schema_2),
+    ]
+    _group_schema = GroupSchema(_array_schemas, _metadata_schema)
+    _key = None
+
+    @pytest.fixture(scope="class")
+    def group_uri(self, tmpdir_factory):
+        """Creates a TileDB Group from GroupSchema and returns scenario dict."""
+        uri = str(tmpdir_factory.mktemp("group1"))
+        ctx = None
+        Group.create_virtual(uri, self._group_schema, self._key, ctx)
+        return uri
+
+    def test_array_schemas(self, group_uri):
+        uri = group_uri
+        assert tiledb.ArraySchema.load(uri, key=self._key) == self._metadata_schema
+        for name, schema in self._array_schemas:
+            array_uri = group_uri + "_" + name
+            assert tiledb.ArraySchema.load(array_uri, key=self._key) == schema
+
+
 class TestNotTileDBURI:
     @pytest.fixture(scope="class")
     def empty_uri(self, tmpdir_factory):

--- a/tests/core/test_group.py
+++ b/tests/core/test_group.py
@@ -65,24 +65,6 @@ class TestNotTileDBURI:
             Group(empty_uri)
 
 
-class TestCreateMetadata:
-    @pytest.fixture(scope="class")
-    def group_uri(self, tmpdir_factory):
-        """Creates a TileDB group and return URI."""
-        uri = str(tmpdir_factory.mktemp("empty_group"))
-        tiledb.group_create(uri)
-        return uri
-
-    def test_create_metadata(self, group_uri):
-        uri = group_uri
-        with Group(uri) as group:
-            assert not group.has_metadata_array
-            group.create_metadata_array()
-            assert not group.has_metadata_array
-            group.reopen()
-            assert group.has_metadata_array
-
-
 class TestSimpleGroup:
 
     _metadata_schema = tiledb.ArraySchema(
@@ -104,15 +86,6 @@ class TestSimpleGroup:
             assert isinstance(group, Group)
             assert group.has_metadata_array
             assert group.meta is not None
-
-    def test_reopen(self, group_uri):
-        with Group(group_uri) as group:
-            group.reopen()
-
-    def test_metadata_array_exists_exception(self, group_uri):
-        with Group(group_uri) as group:
-            with pytest.raises(RuntimeError):
-                group.create_metadata_array()
 
 
 class TestGroupWithArrays:
@@ -148,8 +121,6 @@ class TestGroupWithArrays:
             assert isinstance(array, tiledb.Array)
             assert array.mode == "r"
             assert np.array_equal(array[:, :]["a"], self._A1_data)
-            group.reopen()
-            assert array.mode == "r"
 
     def test_array_metadata(self, group_uri):
         with Group(group_uri, array="A1") as group:
@@ -196,7 +167,7 @@ class TestGroupWithArrays:
 
     def test_no_get_attr_metadata_execption(self, group_uri):
         with Group(group_uri) as group:
-            with pytest.raises(ValueError):
+            with pytest.raises(RuntimeError):
                 _ = group.get_attr_metadata("a")
 
 

--- a/tests/core/test_group_schema.py
+++ b/tests/core/test_group_schema.py
@@ -166,3 +166,22 @@ class TestLoadGroup:
     def test_not_group_exception(self, group_uri):
         with pytest.raises(ValueError):
             GroupSchema.load(group_uri + "/A1")
+
+
+def test_create_virtual(tmpdir):
+    group1 = tmpdir.mkdir("virtual1")
+    group2 = tmpdir.mkdir("virtual2")
+    a1_uri = str(group1.join("array"))
+    a2_uri = str(group2.join("array"))
+    metadata_uri = str(group2.join("group_metadata"))
+    tiledb.Array.create(a1_uri, _array_schema_1)
+    tiledb.Array.create(a2_uri, _array_schema_2)
+    tiledb.Array.create(metadata_uri, _empty_array_schema)
+    array_uris = {
+        "array1": a1_uri,
+        "array2": a2_uri,
+    }
+    group_schema = GroupSchema.load_virtual(array_uris, metadata_uri)
+    assert group_schema["array1"] == _array_schema_1
+    assert group_schema["array2"] == _array_schema_2
+    assert group_schema.metadata_schema == _empty_array_schema

--- a/tests/core/test_group_schema.py
+++ b/tests/core/test_group_schema.py
@@ -180,8 +180,9 @@ def test_create_virtual(tmpdir):
     array_uris = {
         "array1": a1_uri,
         "array2": a2_uri,
+        "__tiledb_group": metadata_uri,
     }
-    group_schema = GroupSchema.load_virtual(array_uris, metadata_uri)
+    group_schema = GroupSchema.load_virtual(array_uris)
     assert group_schema["array1"] == _array_schema_1
     assert group_schema["array2"] == _array_schema_2
     assert group_schema.metadata_schema == _empty_array_schema

--- a/tests/core/test_virtual_group.py
+++ b/tests/core/test_virtual_group.py
@@ -1,0 +1,81 @@
+# Copyright 2021 TileDB Inc.
+# Licensed under the MIT License.
+import numpy as np
+import pytest
+
+import tiledb
+from tiledb.cf import VirtualGroup
+
+_row = tiledb.Dim(name="rows", domain=(1, 4), tile=4, dtype=np.uint64)
+_col = tiledb.Dim(name="cols", domain=(1, 4), tile=4, dtype=np.uint64)
+
+
+_attr_a = tiledb.Attr(name="a", dtype=np.uint64)
+_attr_b = tiledb.Attr(name="b", dtype=np.float64)
+_attr_c = tiledb.Attr(name="c", dtype=np.dtype("U"))
+_array_schema_1 = tiledb.ArraySchema(
+    domain=tiledb.Domain(_row, _col),
+    attrs=[_attr_a],
+)
+_array_schema_2 = tiledb.ArraySchema(
+    domain=tiledb.Domain(_row),
+    sparse=True,
+    attrs=[_attr_b, _attr_c],
+)
+_array_schema_3 = tiledb.ArraySchema(
+    domain=tiledb.Domain(_row, _col),
+    attrs=[_attr_c],
+)
+
+
+class TestVirtualGroupWithArrays:
+
+    _metadata_schema = tiledb.ArraySchema(
+        domain=tiledb.Domain(
+            tiledb.Dim(name="rows", domain=(1, 4), tile=2, dtype=np.uint64)
+        ),
+        attrs=[tiledb.Attr(name="a", dtype=np.uint64)],
+        sparse=True,
+    )
+
+    _A1_data = np.array(
+        ([1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]), dtype=np.uint64
+    )
+
+    @pytest.fixture(scope="class")
+    def array_uris(self, tmpdir_factory):
+        uri = str(tmpdir_factory.mktemp("simple_group"))
+        array_uris = {
+            "A1": uri + "/example1",
+            "A2": uri + "/example2",
+            "A3": uri + "/example3",
+            "__tiledb_group": uri + "/metadta",
+        }
+        tiledb.group_create(uri)
+        tiledb.Array.create(array_uris["__tiledb_group"], self._metadata_schema)
+        tiledb.Array.create(array_uris["A1"], _array_schema_1)
+        with tiledb.DenseArray(array_uris["A1"], mode="w") as array:
+            array[:] = self._A1_data
+        tiledb.Array.create(array_uris["A2"], _array_schema_2)
+        tiledb.Array.create(array_uris["A3"], _array_schema_3)
+        return array_uris
+
+    def test_open_array_from_group(self, array_uris):
+        with VirtualGroup(array_uris, array="A1") as group:
+            array = group.array
+            assert isinstance(array, tiledb.Array)
+            assert array.mode == "r"
+            assert np.array_equal(array[:, :]["a"], self._A1_data)
+
+    def test_open_attr(self, array_uris):
+        with VirtualGroup(array_uris, attr="a") as group:
+            array = group.array
+            assert isinstance(array, tiledb.Array)
+            assert array.mode == "r"
+            assert np.array_equal(array[:, :], self._A1_data)
+
+    def test_array_metadata(self, array_uris):
+        with VirtualGroup(array_uris, mode="w") as group:
+            group.meta["test_key"] = "test_value"
+        with VirtualGroup(array_uris, mode="r") as group:
+            assert group.meta["test_key"] == "test_value"

--- a/tiledb/cf/__init__.py
+++ b/tiledb/cf/__init__.py
@@ -12,6 +12,7 @@ from .core import (
     AttrMetadata,
     Group,
     GroupSchema,
+    VirtualGroup,
 )
 from .creator import DATA_SUFFIX, INDEX_SUFFIX, DataspaceCreator, dataspace_name
 from .engines import from_netcdf, from_netcdf_group

--- a/tiledb/cf/core.py
+++ b/tiledb/cf/core.py
@@ -128,7 +128,7 @@ class Metadata(MutableMapping):
         Raises
             KeyError: If `key` cannot be mapped.
         """
-        return key
+        return key  # pragma: no cover
 
     def _from_tiledb_key(self, tiledb_key: str) -> Optional[str]:
         """Map an internal tiledb key to an external user metadata key.
@@ -137,7 +137,7 @@ class Metadata(MutableMapping):
             The external user metadata key corresponding to `tiledb_key`,
             or None if there is no such corresponding key.
         """
-        return tiledb_key
+        return tiledb_key  # pragma: no cover
 
 
 class ArrayMetadata(Metadata):

--- a/tiledb/cf/core.py
+++ b/tiledb/cf/core.py
@@ -200,7 +200,7 @@ class Group:
         key: If not ``None``, encryption key, or dictionary of encryption keys, to
             decrypt arrays.
         timestamp: If not ``None``, timestamp to open the group metadata and array at.
-        array: If not ``None``, open the array with this name.
+        array: If not ``None``, open the array in the group with this name.
         attr: If not ``None``, open one attribute of the group; indexing a dense array
             will return a Numpy ndarray directly rather than a dictionary. If ``array``
             is specified, the attribute must be inside the specified array. If ``array``
@@ -247,6 +247,25 @@ class Group:
                 _get_array_key(key, array_name),
                 ctx,
             )
+
+    @classmethod
+    def create_virtual(
+        cls,
+        uri: str,
+        group_schema: GroupSchema,
+        key: Optional[Union[Dict[str, str], str]] = None,
+        ctx: Optional[tiledb.Ctx] = None,
+    ):
+        """Create the arrays from a :class:`GroupSchema`.
+
+        Parameters:
+            uri: Uniform resource identifier for TileDB group or array.
+            group_schema: Schema that defines the group to be created.
+            key: If not ``None``, encryption key, or dictionary of encryption keys to
+                decrypt arrays.
+            ctx: If not ``None``, TileDB context wrapper for a TileDB storage manager.
+        """
+        cls.create(uri, group_schema, key, ctx, is_virtual=True)
 
     def __init__(
         self,
@@ -420,7 +439,7 @@ class VirtualGroup(Group):
             None
             if array is None
             else tiledb.open(
-                uri=array_uris[METADATA_ARRAY_NAME],
+                uri=array_uris[array],
                 mode=mode,
                 key=_get_array_key(key, array),
                 attr=attr,

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -339,22 +339,6 @@ class DataspaceCreator:
         """
         Group.create(group_uri, self.to_schema(ctx), key, ctx, is_virtual)
 
-    def create_virtual(
-        self,
-        group_uri: str,
-        key: Optional[Union[Dict[str, str], str]] = None,
-        ctx: Optional[tiledb.Ctx] = None,
-    ):
-        """Creates the TileDB arrays for the CF dataspace in a virtual group.
-
-        Parameters:
-            group_uri: Uniform resource identifier for the TileDB group to be created.
-            key: If not ``None``, encryption key, or dictionary of encryption keys, to
-                decrypt arrays.
-            ctx: If not ``None``, TileDB context wrapper for a TileDB storage manager.
-        """
-        Group.create_virtual(group_uri, self.to_schema(ctx), key, ctx)
-
     @property
     def dim_names(self):
         """A view of the names of dimensions in the CF dataspace."""

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -323,6 +323,7 @@ class DataspaceCreator:
         group_uri: str,
         key: Optional[Union[Dict[str, str], str]] = None,
         ctx: Optional[tiledb.Ctx] = None,
+        is_virtual: bool = False,
     ):
         """Creates a TileDB group and arrays for the CF dataspace.
 
@@ -331,8 +332,28 @@ class DataspaceCreator:
             key: If not ``None``, encryption key, or dictionary of encryption keys, to
                 decrypt arrays.
             ctx: If not ``None``, TileDB context wrapper for a TileDB storage manager.
+            is_virtual: If ``True``, create a virtual group using ``uri`` as the name
+                for the group metadata array. All other arrays will be named using the
+                convention ``{uri}_{array_name}`` where ``array_name`` is the name of
+                the array.
         """
-        Group.create(group_uri, self.to_schema(ctx), key, ctx)
+        Group.create(group_uri, self.to_schema(ctx), key, ctx, is_virtual)
+
+    def create_virtual(
+        self,
+        group_uri: str,
+        key: Optional[Union[Dict[str, str], str]] = None,
+        ctx: Optional[tiledb.Ctx] = None,
+    ):
+        """Creates the TileDB arrays for the CF dataspace in a virtual group.
+
+        Parameters:
+            group_uri: Uniform resource identifier for the TileDB group to be created.
+            key: If not ``None``, encryption key, or dictionary of encryption keys, to
+                decrypt arrays.
+            ctx: If not ``None``, TileDB context wrapper for a TileDB storage manager.
+        """
+        Group.create_virtual(group_uri, self.to_schema(ctx), key, ctx)
 
     @property
     def dim_names(self):


### PR DESCRIPTION
A "virtual" group is a collection of TileDB arrays that are contextually related, but not stored in a TileDB group. They can be created by using a mapping for array names to array URIs.

Breaking Changes:

* Remove property `metadata_key` from the `Group` class
* Remove function `reopen` from the `Group` class

Features:

* Add parameter `is_virtual` to classmethod `Group.create` for flagging if the created group should be a virtual group.
* Add classmethod `Group.create_virtual` that creates a virtual group from a mapping of array names to URIs.
* Add a classmethod `GroupSchema.load_virtual` for loading a virtual group defined by a mapping from array names to URIs.
* Add example notebook for creating groups.

Refactor:

* Remove no longer needed private variables from the `Group` class
* Add `_get_array_key` helper function
* Split `_get_array_uri` into `_get_array_uri_` and `_get_metadata_array_uri` with support for virtual groups.

Tests:

* Update core tests to cover new features.