### PR TITLE
Add virtual groups support to NetCDF4ConverterEngine

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,12 +5,19 @@
 ### Breaking Behavior
 
 * Makes `NetCDF4ConverterEngine` methods `add_ncvar_to_attr` and `add_ncdim_to_dim` private.
+* Renames method `create` in `DataspaceConverter` to `create_group` and changes method parameters.
+* Renames method `convert` in `NetCDF4ConverterEngine` to `convert_to_group` and changes method parameters.
+* Renames method `copy` in `NetCDF4ConverterEninge` to `copy_group` and changes method parameters.
+* Adds `use_virtual_groups` parameter to `from_netcdf` and `from_netcdf_group` functions.
 
 ### New Features
 
 * Adds the parameter `is_virtual` to classmethod `Group.create` for flagging if the created group should be a virtual group.
 * Adds the classmethod `Group.create_virtual` that creates a virtual group from a mapping of array names to URIs.
 * Adds a classmethod `GroupSchema.load_virtual` for loading a virtual group defined by a mapping from array names to URIs.
+* Adds method `create_virtual_group` to `DataspaceConverter`.
+* Adds method `convert_to_virtual_group` in `NetCDF4ConverterEngine`.
+* Adds method `copy_to_virtual_group` in NetCDF4ConverterEngine`.
 
 ### Improvements
 
@@ -20,6 +27,7 @@
 
 * Fixes detection of tiles from NetCDF variables with matching chunk sizes.
 * Fixes f-strings in NetCDF4ConverterEngine `__repr__` method
+* Fixes
 
 ## TileDB-CF-Py Release 0.2.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,8 +26,8 @@
 ### Bug fixes
 
 * Fixes detection of tiles from NetCDF variables with matching chunk sizes.
-* Fixes f-strings in NetCDF4ConverterEngine `__repr__` method
-* Fixes
+* Fixes ouput in NetCDF4ConverterEngine and GroupSchema `__repr__` methods.
+
 
 ## TileDB-CF-Py Release 0.2.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,7 +18,8 @@
 
 ### Bug fixes
 
-* Fix detection of tiles from NetCDF variables with matching chunk sizes.
+* Fixes detection of tiles from NetCDF variables with matching chunk sizes.
+* Fixes f-strings in NetCDF4ConverterEngine `__repr__` method
 
 ## TileDB-CF-Py Release 0.2.0
 

--- a/tests/engines/netcdf4_engine/conftest.py
+++ b/tests/engines/netcdf4_engine/conftest.py
@@ -88,6 +88,7 @@ def simple2_netcdf_file(tmpdir_factory):
             {"varname": "x2", "datatype": np.float64, "dimensions": ("row",)},
         ],
         variable_data={"x1": xdata, "x2": xdata ** 2},
+        group_metadata={"name": "simple2"},
     )
     return example
 

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -197,7 +197,7 @@ def test_converter_from_netcdf(netcdf_test_case, tmpdir):
     converter = NetCDF4ConverterEngine.from_file(netcdf_test_case.filepath)
     uri = str(tmpdir.mkdir("output").join(name))
     assert isinstance(repr(converter), str)
-    converter.convert(uri)
+    converter.convert_to_group(uri)
     for attr_name, var_name in attr_to_var_map[name].items():
         with Group(uri, attr=attr_name) as group:
             nonempty_domain = group.array.nonempty_domain()
@@ -213,8 +213,8 @@ def test_converter_from_netcdf_2(netcdf_test_case, tmpdir):
     converter = NetCDF4ConverterEngine.from_file(netcdf_test_case.filepath)
     uri = str(tmpdir.mkdir("output").join(name))
     assert isinstance(repr(converter), str)
-    converter.create(uri)
-    converter.copy(uri)
+    converter.create_group(uri)
+    converter.copy_to_group(uri)
     for attr_name, var_name in attr_to_var_map[name].items():
         with Group(uri, attr=attr_name) as group:
             nonempty_domain = group.array.nonempty_domain()
@@ -365,9 +365,9 @@ def test_not_implemented_error(empty_netcdf_file):
 def test_copy_no_var_error(tmpdir, simple1_netcdf_file, simple2_netcdf_file):
     converter = NetCDF4ConverterEngine.from_file(simple2_netcdf_file.filepath)
     uri = str(tmpdir.mkdir("output").join("test_copy_error"))
-    converter.create(uri)
+    converter.create_group(uri)
     with pytest.raises(KeyError):
-        converter.copy(uri, input_file=simple1_netcdf_file.filepath)
+        converter.copy_to_group(uri, input_file=simple1_netcdf_file.filepath)
 
 
 def test_bad_array_name_error(simple2_netcdf_file):

--- a/tiledb/cf/core.py
+++ b/tiledb/cf/core.py
@@ -582,10 +582,9 @@ class GroupSchema(Mapping):
     def __repr__(self) -> str:
         """Returns the object representation of this GroupSchema in string form."""
         output = StringIO()
-        output.write("  GroupSchema (\n")
+        output.write("GroupSchema:\n")
         for name, schema in self.items():
-            output.write(f"{name} {repr(schema)}")
-        output.write(")\n")
+            output.write(f"'{name}': {repr(schema)}")
         return output.getvalue()
 
     def check(self):

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -318,26 +318,41 @@ class DataspaceCreator:
         """A view of the names of attributes in the CF dataspace."""
         return self._attr_to_array.keys()
 
-    def create(
+    def create_group(
         self,
-        group_uri: str,
+        uri: str,
         key: Optional[Union[Dict[str, str], str]] = None,
         ctx: Optional[tiledb.Ctx] = None,
-        is_virtual: bool = False,
     ):
         """Creates a TileDB group and arrays for the CF dataspace.
 
         Parameters:
-            group_uri: Uniform resource identifier for the TileDB group to be created.
+            uri: Uniform resource identifier for the TileDB group to be created, or
+                prefix URIs for the TileDB arrays that will be created if
+                ``use_virtual_groups=True``.
             key: If not ``None``, encryption key, or dictionary of encryption keys, to
                 decrypt arrays.
             ctx: If not ``None``, TileDB context wrapper for a TileDB storage manager.
-            is_virtual: If ``True``, create a virtual group using ``uri`` as the name
-                for the group metadata array. All other arrays will be named using the
-                convention ``{uri}_{array_name}`` where ``array_name`` is the name of
-                the array.
         """
-        Group.create(group_uri, self.to_schema(ctx), key, ctx, is_virtual)
+        Group.create(uri, self.to_schema(ctx), key, ctx)
+
+    def create_virtual_group(
+        self,
+        uri: str,
+        key: Optional[Union[Dict[str, str], str]] = None,
+        ctx: Optional[tiledb.Ctx] = None,
+    ):
+        """Creates TileDB arrays for the CF dataspace.
+
+        Parameters:
+            uri: Uniform resource identifier for the TileDB group to be created, or
+                prefix URIs for the TileDB arrays that will be created if
+                ``use_virtual_groups=True``.
+            key: If not ``None``, encryption key, or dictionary of encryption keys, to
+                decrypt arrays.
+            ctx: If not ``None``, TileDB context wrapper for a TileDB storage manager.
+        """
+        Group.create_virtual(uri, self.to_schema(ctx), key, ctx)
 
     @property
     def dim_names(self):

--- a/tiledb/cf/engines/netcdf4_engine.py
+++ b/tiledb/cf/engines/netcdf4_engine.py
@@ -382,9 +382,9 @@ class NetCDF4ConverterEngine(DataspaceCreator):
         output = StringIO()
         output.write(f"{super().__repr__()}\n")
         if self.default_input_file is not None:
-            output.write("Default NetCDF file: {self.default_input_file}\n")
+            output.write(f"Default NetCDF file: {self.default_input_file}\n")
         if self.default_group_path is not None:
-            output.write("Deault NetCDF group path: {self.default_group_path}\n")
+            output.write(f"Deault NetCDF group path: {self.default_group_path}\n")
         return output.getvalue()
 
     def add_array(


### PR DESCRIPTION
Breaking Behavior
* Rename method `create` in `DataspaceConverter` to `create_group` and
rename method parameters.
* Rename method `convert` in `NetCDF4ConverterEngine` to
`convert_to_group` and rename function parameters.
* Rename method `copy` in `NetCDF4ConverterEninge` to `copy_group` and
rename method parameters.
* Add `use_virtual_groups` parameter to `from_netcdf` and
`from_netcdf_group` functions

Features
* Add method `create_virtual_group` to `DataspaceConverter`
* Add method `convert_to_virtual_group` in `NetCDF4ConverterEngine`
* Add method `copy_to_virtual_group` in NetCDF4ConverterEngine`

Docs
* Fix docstrings missing parameter definitions

Fixes
* Update `__repr__` for GroupSchema and NetCDF4ConverterEngine.