### PR TITLE
Refactor NetCDF4 dimension converters and remove `collect_scalars` option

### DIFF
--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -282,7 +282,6 @@ def test_convert_to_scalar_sparse_array(multiscalars_netcdf_file, tmpdir):
     converter = NetCDF4ConverterEngine.from_file(
         multiscalars_netcdf_file.filepath,
         collect_attrs=False,
-        collect_scalar_attrs=True,
     )
     for array_name in converter.array_names:
         converter.set_array_properties(array_name, sparse=True)
@@ -359,22 +358,9 @@ def test_collect_scalar_attrs(multiscalars_netcdf_file):
     converter = NetCDF4ConverterEngine.from_file(
         multiscalars_netcdf_file.filepath,
         collect_attrs=False,
-        collect_scalar_attrs=True,
     )
     assert set(converter.array_names) == {"scalars"}
     assert set(converter._array_creators["scalars"].attr_names) == {"s1", "s2", "s3"}
-
-
-def test_no_collect_scalars(multiscalars_netcdf_file):
-    converter = NetCDF4ConverterEngine.from_file(
-        multiscalars_netcdf_file.filepath,
-        collect_attrs=False,
-        collect_scalar_attrs=False,
-    )
-    assert set(converter.array_names) == {"s1", "s2", "s3"}
-    assert set(converter._array_creators["s1"].attr_names) == {"s1"}
-    assert set(converter._array_creators["s2"].attr_names) == {"s2"}
-    assert set(converter._array_creators["s3"].attr_names) == {"s3"}
 
 
 def test_variable_fill(tmpdir):

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -457,11 +457,10 @@ def test_rename_dim(simple1_netcdf_file):
     assert set(converter.dim_names) == set(["col"])
 
 
-def test_not_implemented_error(empty_netcdf_file):
-    converter = NetCDF4ConverterEngine.from_file(empty_netcdf_file.filepath)
-    converter.add_array("A1", [])
+def test_not_implemented_error(simple1_netcdf_file):
+    converter = NetCDF4ConverterEngine.from_file(simple1_netcdf_file.filepath)
     with pytest.raises(NotImplementedError):
-        converter.add_attr("a1", "A1", np.float64)
+        converter.add_attr("a1", "array0", np.float64)
 
 
 def test_copy_no_var_error(tmpdir, simple1_netcdf_file, simple2_netcdf_file):

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -466,7 +466,7 @@ def test_not_implemented_error(simple1_netcdf_file):
 def test_bad_dims_error(simple1_netcdf_file):
     converter = NetCDF4ConverterEngine()
     converter.add_dim("row", (0, 10), np.uint32)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         converter.add_array("array0", ("row",))
 
 

--- a/tests/engines/netcdf4_engine/test_netcdf_dimension_converter.py
+++ b/tests/engines/netcdf4_engine/test_netcdf_dimension_converter.py
@@ -98,14 +98,16 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", None)
             converter = NetCDFDimToDimConverter.from_netcdf(dim, 100, np.uint64)
-            assert converter.get_values(dataset, sparse=True) is None
+            with pytest.raises(ValueError):
+                converter.get_values(dataset, sparse=True)
 
     def test_dense_values_no_data(self):
         netCDF4 = pytest.importorskip("netCDF4")
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", None)
             converter = NetCDFDimToDimConverter.from_netcdf(dim, 100, np.uint64)
-            assert converter.get_values(dataset, sparse=False) is None
+            with pytest.raises(ValueError):
+                converter.get_values(dataset, sparse=False)
 
     def test_get_sparse_values(self):
         netCDF4 = pytest.importorskip("netCDF4")

--- a/tests/engines/netcdf4_engine/test_netcdf_dimension_converter.py
+++ b/tests/engines/netcdf4_engine/test_netcdf_dimension_converter.py
@@ -63,7 +63,7 @@ class TestNetCDFDimToDimConverterSimpleDim:
 
 
 class TestNetCDFDimToDimConverterUnlimitedDim:
-    """This class teests the NetCDFDimToDimConverter class for an unlimited
+    """This class tests the NetCDFDimToDimConverter class for an unlimited
     NetCDF dimension."""
 
     def test_class_properties(self):

--- a/tiledb/cf/__init__.py
+++ b/tiledb/cf/__init__.py
@@ -58,12 +58,6 @@ def cli():
     help="Collect variables with the same dimensions into a single array.",
 )
 @click.option(
-    "--collect-scalar-attrs/--no-collect-scalar-attrs",
-    default=True,
-    show_default=True,
-    help="Collect scalary variables into a single array.",
-)
-@click.option(
     "-k",
     "--output-key",
     type=str,
@@ -105,7 +99,6 @@ def netcdf_convert(
     unlimited_dim_size: int,
     dim_dtype: str,
     collect_attrs: bool,
-    collect_scalar_attrs: bool,
 ):
     """Converts a NetCDF input file to nested TileDB groups."""
     from_netcdf(
@@ -120,5 +113,4 @@ def netcdf_convert(
         tiles_by_var=None,
         tiles_by_dims=None,
         collect_attrs=collect_attrs,
-        collect_scalar_attrs=collect_scalar_attrs,
     )

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -646,6 +646,10 @@ class ArrayCreator:
         self.offsets_filters = offsets_filters
         self.allows_duplicates = allows_duplicates
         self.sparse = sparse
+        self._post_init()
+
+    def _post_init(self):
+        pass
 
     def __repr__(self) -> str:
         output = StringIO()

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -646,9 +646,9 @@ class ArrayCreator:
         self.offsets_filters = offsets_filters
         self.allows_duplicates = allows_duplicates
         self.sparse = sparse
-        self._post_init()
+        self.__post_init__()
 
-    def _post_init(self):
+    def __post_init__(self):
         pass
 
     def __repr__(self) -> str:

--- a/tiledb/cf/engines/__init__.py
+++ b/tiledb/cf/engines/__init__.py
@@ -25,7 +25,6 @@ def from_netcdf(
     ] = None,
     use_virtual_groups: bool = False,
     collect_attrs: bool = True,
-    collect_scalar_attrs: bool = True,
 ):
     """Converts a NetCDF input file to nested TileDB CF dataspaces.
 
@@ -57,8 +56,6 @@ def from_netcdf(
             name of the array.
         collect_attrs: If True, store all attributes with the same dimensions
             in the same array. Otherwise, store each attribute in a scalar array.
-        collect_scalar_attrs: If true, store all attributes with no dimensions
-            in the same array. This is always done if collect_attributes=True.
     """
     from .netcdf4_engine import NetCDF4ConverterEngine, open_netcdf_group
 
@@ -77,7 +74,6 @@ def from_netcdf(
             tiles_by_var.get(netcdf_group.path),
             tiles_by_dims.get(netcdf_group.path),
             collect_attrs=collect_attrs,
-            collect_scalar_attrs=collect_scalar_attrs,
         )
         group_uri = (
             output_uri
@@ -99,7 +95,6 @@ def from_netcdf(
             tiles_by_var.get(netcdf_group.path),
             tiles_by_dims.get(netcdf_group.path),
             collect_attrs=collect_attrs,
-            collect_scalar_attrs=collect_scalar_attrs,
         )
         group_uri = output_uri + netcdf_group.path
         converter.convert_to_group(
@@ -135,7 +130,6 @@ def from_netcdf_group(
     tiles_by_dims: Optional[Dict[Sequence[str], Optional[Sequence[int]]]] = None,
     use_virtual_groups: bool = False,
     collect_attrs: bool = True,
-    collect_scalar_attrs: bool = True,
 ):
     """Converts a group in a NetCDF file or :class:`netCDF4.Group` to a TileDB CF
     dataspace.
@@ -176,7 +170,6 @@ def from_netcdf_group(
             tiles_by_var,
             tiles_by_dims,
             collect_attrs=collect_attrs,
-            collect_scalar_attrs=collect_scalar_attrs,
         )
         if use_virtual_groups:
             converter.convert_to_virtual_group(
@@ -195,7 +188,6 @@ def from_netcdf_group(
             tiles_by_var,
             tiles_by_dims,
             collect_attrs=collect_attrs,
-            collect_scalar_attrs=collect_scalar_attrs,
         )
         if use_virtual_groups:
             converter.convert_to_virtual_group(output_uri, output_key, output_ctx)

--- a/tiledb/cf/engines/netcdf4_engine.py
+++ b/tiledb/cf/engines/netcdf4_engine.py
@@ -137,6 +137,53 @@ class NetCDFDimToDimConverter(NetCDFDimConverter):
 
 
 @dataclass
+class NetCDFScalarDimConverter(NetCDFDimConverter):
+    """Data for converting from a NetCDF dimension to a TileDB dimension.
+
+    Parameters:
+        name: Name of the TileDB dimension.
+        domain: The (inclusive) interval on which the dimension is valid.
+        dtype: The numpy dtype of the values and domain of the dimension.
+
+    Attributes:
+        name: Name of the TileDB dimension.
+        domain: The (inclusive) interval on which the dimension is valid.
+        dtype: The numpy dtype of the values and domain of the dimension.
+    """
+
+    def __repr__(self):
+        return f" Scalar dimensions -> {super().__repr__()}"
+
+    def get_values(self, netcdf_group: netCDF4.Dataset, sparse: bool):
+        """Get dimension values from a NetCDF group.
+
+        Parameters:
+            netcdf_group: NetCDF group to get the dimension values from.
+            sparse: ``True`` if copying into a sparse array and ``False`` if copying
+                into a dense array.
+        """
+        if sparse:
+            return np.array([0])
+        return slice(1)
+
+    @classmethod
+    def create(cls, dim_name: str, dtype: np.dtype):
+        """Returns a :class:`NetCDFDimToDimConverter` from a
+        :class:`netcdf4.Dimension`.
+
+        Parameters:
+            dim: The input netCDF4 dimension.
+            unlimited_dim_size: The size of the domain of the output TileDB
+                dimension when the input NetCDF dimension is unlimited.
+            dtype: The numpy dtype of the values and domain of the output TileDB
+                dimension.
+            dim_name: The name of the output TileDB dimension. If ``None``, the name
+                will be the same as the name of the input NetCDF dimension.
+        """
+        return cls(dim_name, (0, 0), np.dtype(dtype))
+
+
+@dataclass
 class NetCDFVariableConverter(AttrCreator):
     """Data for converting from a NetCDF variable to a TileDB attribute.
 

--- a/tiledb/cf/engines/netcdf4_engine.py
+++ b/tiledb/cf/engines/netcdf4_engine.py
@@ -512,7 +512,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
                 if dim.name == "__scalars":
                     raise NotImplementedError(
                         "Support for converting a NetCDF file with reserved dimension "
-                        "name '__scalars' not yet implemented."
+                        "name '__scalars' is not yet implemented."
                     )
                 if dim.name not in converter.dim_names:
                     converter._add_ncdim_to_dim_converter(
@@ -588,7 +588,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
                 if dim.name == "__scalars":
                     raise NotImplementedError(
                         "Support for converting a NetCDF file with reserved dimension "
-                        "name '__scalars' not yet implemented."
+                        "name '__scalars' is not yet implemented."
                     )
                 if dim.name not in converter.dim_names:
                     converter._add_ncdim_to_dim_converter(
@@ -697,9 +697,6 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             raise ValueError(
                 f"Cannot add new array with name '{array_name}'. {str(err)}"
             ) from err
-        if not dims:
-            dims = ("__scalars",)
-            self.add_dim("__scalars", (0, 0), np.dtype(np.uint32))
         array_dims = tuple(self._dims[dim_name] for dim_name in dims)
         self._array_creators[array_name] = NetCDFArrayConverter(
             array_dims,


### PR DESCRIPTION
Refactor:
Create an internal class for converting NetCDF4 dimensions that includes a method for getting the dimension query values for sparse and dense arrays.

Change:
Remove the `collect_scalars` option, and always collect scalars into a single array.