### PR TITLE
Create _repr_html_ for viewing data heavy classes in Jupyter

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ flake8==3.9.0
 mypy==0.812
 flake8-bugbear==21.3.2
 pytest==6.2.2
+pytidylib==0.3.2

--- a/tests/core/test_group_schema.py
+++ b/tests/core/test_group_schema.py
@@ -14,7 +14,7 @@ _col = tiledb.Dim(name="cols", domain=(1, 8), tile=2, dtype=np.uint64)
 _attr0 = tiledb.Attr(name="attr", dtype=np.int32)
 _attr_a = tiledb.Attr(name="a", dtype=np.uint64)
 _attr_b = tiledb.Attr(name="b", dtype=np.float64)
-_attr_c = tiledb.Attr(name="c", dtype=np.dtype("U"))
+_attr_c = tiledb.Attr(name="c", dtype=np.bytes_)
 _attr_d = tiledb.Attr(name="d", dtype=np.uint64)
 _empty_array_schema = tiledb.ArraySchema(
     domain=tiledb.Domain(_dim0),
@@ -84,6 +84,21 @@ class TestGroupSchema:
                 arrays
             ), f"Get all arrays for attribute '{attr_name}' failed."
             assert group_schema.has_attr(attr_name)
+
+    @pytest.mark.parametrize("scenario", _scenarios)
+    def test_repr_html(self, scenario):
+        try:
+            tidylib = pytest.importorskip("tidylib")
+            group_schema = GroupSchema(
+                array_schemas=scenario["array_schemas"],
+                metadata_schema=scenario["metadata_schema"],
+                use_default_metadata_schema=False,
+            )
+            html_summary = group_schema._repr_html_()
+            _, errors = tidylib.tidy_fragment(html_summary)
+        except OSError:
+            pytest.skip("unable to import libtidy backend")
+        assert not bool(errors), str(errors)
 
     def test_not_equal(self):
         schema1 = GroupSchema({"A1": _array_schema_1}, None, False)

--- a/tests/creator/test_dataspace_creator.py
+++ b/tests/creator/test_dataspace_creator.py
@@ -39,6 +39,15 @@ class TestDataspaceCreatorExample1:
     def test_repr(self, dataspace_creator):
         assert isinstance(repr(dataspace_creator), str)
 
+    def test_repr_html(self, dataspace_creator):
+        try:
+            tidylib = pytest.importorskip("tidylib")
+            html_summary = dataspace_creator._repr_html_()
+            _, errors = tidylib.tidy_fragment(html_summary)
+        except OSError:
+            pytest.skip("unable to import libtidy backend")
+        assert not bool(errors)
+
     def test_array_names(self, dataspace_creator):
         assert set(dataspace_creator.array_names) == {"A1", "A2", "A3"}
 

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -77,6 +77,16 @@ class ConvertNetCDFBase:
         converter.convert_to_group(uri)
         self.check_attrs(uri)
 
+    def test_converter(self, netcdf_file):
+        converter = NetCDF4ConverterEngine.from_file(netcdf_file)
+        try:
+            tidylib = pytest.importorskip("tidylib")
+            html_summary = converter._repr_html_()
+            _, errors = tidylib.tidy_fragment(html_summary)
+        except OSError:
+            pytest.skip("unable to import libtidy backend")
+        assert not bool(errors), str(errors)
+
 
 class TestConverterSimpleNetCDF(ConvertNetCDFBase):
     """NetCDF conversion test cases for a simple NetCDF file.

--- a/tiledb/cf/core.py
+++ b/tiledb/cf/core.py
@@ -19,49 +19,50 @@ METADATA_ARRAY_NAME = "__tiledb_group"
 ATTR_METADATA_FLAG = "__tiledb_attr."
 
 
-def _array_schema_html(array_schema: tiledb.ArraySchema) -> str:
+def _array_schema_html(schema: tiledb.ArraySchema) -> str:
     """Returns a HTML representation of a TileDB array."""
     output = StringIO()
-    output.write("<section>\n")
     output.write("<ul>\n")
     output.write("<li>\n")
     output.write("Domain\n")
     output.write("<table>\n")
-    for i in range(array_schema.domain.ndim):
+    for i in range(schema.domain.ndim):
         output.write(
-            f"<tr><td align=left>{repr(array_schema.domain.dim(i))}</td></tr>\n"
+            f'<tr><td style="text-align: left;">{repr(schema.domain.dim(i))}</td>'
+            f"</tr>\n"
         )
     output.write("</table>\n")
     output.write("</li>\n")
     output.write("<li>\n")
     output.write("Attributes\n")
     output.write("<table>\n")
-    for i in range(array_schema.nattr):
-        output.write(f"<tr><td align=left>{repr(array_schema.attr(i))}</td></tr>\n")
+    for i in range(schema.nattr):
+        output.write(
+            f'<tr><td style="text-align: left;">{repr(schema.attr(i))}</td></tr>\n'
+        )
     output.write("</table>\n")
     output.write("</li>\n")
     output.write("<li>\n")
     output.write("Array properties")
     output.write(
         f"<table>\n"
-        f"<tr><td align=left>cell_order={array_schema.cell_order}</td></tr>\n"
-        f"<tr><td align=left>tile_order={array_schema.tile_order}</td></tr>\n"
-        f"<tr><td align=left>capacity={array_schema.capacity}</td></tr>\n"
-        f"<tr><td align=left>sparse={array_schema.sparse}</td></tr>\n"
+        f'<tr><td style="text-align: left;">cell_order={schema.cell_order}</td></tr>\n'
+        f'<tr><td style="text-align: left;">tile_order={schema.tile_order}</td></tr>\n'
+        f'<tr><td style="text-align: left;">capacity={schema.capacity}</td></tr>\n'
+        f'<tr><td style="text-align: left;">sparse={schema.sparse}</td></tr>\n'
     )
-    if array_schema.sparse:
+    if schema.sparse:
         output.write(
-            f"<tr><td align=left>allows_duplicates"
-            f"={array_schema.allows_duplicates}</td></tr>\n"
+            f'<tr><td style="text-align: left;">allows_duplicates'
+            f"={schema.allows_duplicates}</td></tr>\n"
         )
-    if array_schema.coords_filters is not None:
-        output.write(
-            f"<tr><td align=left>coords_filters={array_schema.coords_filters}</td>\n"
-        )
+    output.write(
+        f'<tr><td style="text-align: left">coords_filters={schema.coords_filters}'
+        f"</td>\n"
+    )
     output.write("</table>\n")
     output.write("</li>\n")
     output.write("</ul>\n")
-    output.write("</section>\n")
     return output.getvalue()
 
 
@@ -682,16 +683,12 @@ class GroupSchema(Mapping):
         if self._metadata_schema is not None:
             output.write("<details>\n")
             output.write("<summary>ArraySchema for Group Metadata Array</summary>\n")
-            output.write("<p>\n")
             output.write(_array_schema_html(self._metadata_schema))
-            output.write("</p>\n")
             output.write("</details>\n")
         for name, schema in self.items():
             output.write("<details>\n")
             output.write(f"<summary>ArraySchema <em>{name}</em></summary>\n")
-            output.write("<p>")
             output.write(_array_schema_html(schema))
-            output.write("</p>\n")
             output.write("</details>\n")
         output.write("</section>\n")
         return output.getvalue()

--- a/tiledb/cf/core.py
+++ b/tiledb/cf/core.py
@@ -49,7 +49,7 @@ def _array_schema_html(array_schema: tiledb.ArraySchema) -> str:
     )
     if array_schema.sparse:
         output.write(
-            f"<tr><th>allows_duplicates</th>i"
+            f"<tr><th>allows_duplicates</th>"
             f"<th>{array_schema.allows_duplicates}</th></tr>\n"
         )
     if array_schema.coords_filters is not None:

--- a/tiledb/cf/core.py
+++ b/tiledb/cf/core.py
@@ -19,6 +19,50 @@ METADATA_ARRAY_NAME = "__tiledb_group"
 ATTR_METADATA_FLAG = "__tiledb_attr."
 
 
+def _array_schema_html(array_schema: tiledb.ArraySchema) -> str:
+    """Returns a HTML representation of a TileDB array."""
+    output = StringIO()
+    output.write("<section>\n")
+    output.write("<ul>\n")
+    output.write("<li>\n")
+    output.write("Domain\n")
+    output.write("<table>\n")
+    for i in range(array_schema.domain.ndim):
+        output.write(f"<tr><th>{repr(array_schema.domain.dim(i))}</th></tr>\n")
+    output.write("</table>\n")
+    output.write("</li>\n")
+    output.write("<li>\n")
+    output.write("Attributes\n")
+    output.write("<table>\n")
+    for i in range(array_schema.nattr):
+        output.write(f"<tr><th>{repr(array_schema.attr(i))}</th></tr>\n")
+    output.write("</table>\n")
+    output.write("</li>\n")
+    output.write("<li>\n")
+    output.write("Array properties")
+    output.write(
+        f"<table>\n"
+        f"<tr><th>cell_order</th><th>{array_schema.cell_order}</th></tr>\n"
+        f"<tr><th>tile_order</th><th>{array_schema.tile_order}</th></tr>\n"
+        f"<tr><th>capacity</th><th>{array_schema.capacity}</th></tr>\n"
+        f"<tr><th>sparse</th><th>{array_schema.sparse}</th></tr>\n"
+    )
+    if array_schema.sparse:
+        output.write(
+            f"<tr><th>allows_duplicates</th>i"
+            f"<th>{array_schema.allows_duplicates}</th></tr>\n"
+        )
+    if array_schema.coords_filters is not None:
+        output.write(
+            f"<tr><th>coords_filters</th><th>{array_schema.coords_filters}</th>\n"
+        )
+    output.write("</table>\n")
+    output.write("</li>\n")
+    output.write("</ul>\n")
+    output.write("</section>\n")
+    return output.getvalue()
+
+
 def _get_array_uri(group_uri: str, array_name: str, is_virtual: bool) -> str:
     """Returns a URI for an array with name ``array_name`` inside a group at URI
         ``group_uri``.
@@ -626,6 +670,28 @@ class GroupSchema(Mapping):
             output.write(f"Group metadata schema: {repr(self._metadata_schema)}")
         for name, schema in self.items():
             output.write(f"'{name}': {repr(schema)}")
+        return output.getvalue()
+
+    def _repr_html_(self) -> str:
+        """Returns the object representation of this GroupSchame as HTML."""
+        output = StringIO()
+        output.write("<section>\n")
+        output.write("<h3>TileDB-CF GroupSchema</h3>\n")
+        if self._metadata_schema is not None:
+            output.write("<details>\n")
+            output.write("<summary>Group Metadata ArraySchema</summary>\n")
+            output.write("<p>\n")
+            output.write(_array_schema_html(self._metadata_schema))
+            output.write("</p>\n")
+            output.write("</details>\n")
+        for name, schema in self.items():
+            output.write("<details>\n")
+            output.write(f"<summary>'{name}' ArraySchema</summary>\n")
+            output.write("<p>")
+            output.write(_array_schema_html(schema))
+            output.write("</p>\n")
+            output.write("</details>\n")
+        output.write("</section>\n")
         return output.getvalue()
 
     def check(self):

--- a/tiledb/cf/core.py
+++ b/tiledb/cf/core.py
@@ -28,33 +28,35 @@ def _array_schema_html(array_schema: tiledb.ArraySchema) -> str:
     output.write("Domain\n")
     output.write("<table>\n")
     for i in range(array_schema.domain.ndim):
-        output.write(f"<tr><th>{repr(array_schema.domain.dim(i))}</th></tr>\n")
+        output.write(
+            f"<tr><td align=left>{repr(array_schema.domain.dim(i))}</td></tr>\n"
+        )
     output.write("</table>\n")
     output.write("</li>\n")
     output.write("<li>\n")
     output.write("Attributes\n")
     output.write("<table>\n")
     for i in range(array_schema.nattr):
-        output.write(f"<tr><th>{repr(array_schema.attr(i))}</th></tr>\n")
+        output.write(f"<tr><td align=left>{repr(array_schema.attr(i))}</td></tr>\n")
     output.write("</table>\n")
     output.write("</li>\n")
     output.write("<li>\n")
     output.write("Array properties")
     output.write(
         f"<table>\n"
-        f"<tr><th>cell_order</th><th>{array_schema.cell_order}</th></tr>\n"
-        f"<tr><th>tile_order</th><th>{array_schema.tile_order}</th></tr>\n"
-        f"<tr><th>capacity</th><th>{array_schema.capacity}</th></tr>\n"
-        f"<tr><th>sparse</th><th>{array_schema.sparse}</th></tr>\n"
+        f"<tr><td align=left>cell_order={array_schema.cell_order}</td></tr>\n"
+        f"<tr><td align=left>tile_order={array_schema.tile_order}</td></tr>\n"
+        f"<tr><td align=left>capacity={array_schema.capacity}</td></tr>\n"
+        f"<tr><td align=left>sparse={array_schema.sparse}</td></tr>\n"
     )
     if array_schema.sparse:
         output.write(
-            f"<tr><th>allows_duplicates</th>"
-            f"<th>{array_schema.allows_duplicates}</th></tr>\n"
+            f"<tr><td align=left>allows_duplicates"
+            f"={array_schema.allows_duplicates}</td></tr>\n"
         )
     if array_schema.coords_filters is not None:
         output.write(
-            f"<tr><th>coords_filters</th><th>{array_schema.coords_filters}</th>\n"
+            f"<tr><td align=left>coords_filters={array_schema.coords_filters}</td>\n"
         )
     output.write("</table>\n")
     output.write("</li>\n")
@@ -676,17 +678,17 @@ class GroupSchema(Mapping):
         """Returns the object representation of this GroupSchame as HTML."""
         output = StringIO()
         output.write("<section>\n")
-        output.write("<h3>TileDB-CF GroupSchema</h3>\n")
+        output.write(f"<h3>{self.__class__.__name__}</h3>\n")
         if self._metadata_schema is not None:
             output.write("<details>\n")
-            output.write("<summary>Group Metadata ArraySchema</summary>\n")
+            output.write("<summary>ArraySchema for Group Metadata Array</summary>\n")
             output.write("<p>\n")
             output.write(_array_schema_html(self._metadata_schema))
             output.write("</p>\n")
             output.write("</details>\n")
         for name, schema in self.items():
             output.write("<details>\n")
-            output.write(f"<summary>'{name}' ArraySchema</summary>\n")
+            output.write(f"<summary>ArraySchema <em>{name}</em></summary>\n")
             output.write("<p>")
             output.write(_array_schema_html(schema))
             output.write("</p>\n")

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -893,6 +893,7 @@ class ArrayCreator:
 
     def html_summary(self) -> str:
         """Returns a string HTML summary of the :class:`ArrayCreator`."""
+        cell_style = 'style="text-align: left;"'
         output = StringIO()
         output.write("<ul>\n")
         output.write("<li>\n")
@@ -900,7 +901,7 @@ class ArrayCreator:
         output.write("<table>\n")
         for dim_creator in self._dim_creators:
             output.write(
-                f'<tr><td style="text-align: left;">{dim_creator.html_summary()}</td></tr>\n'
+                f"<tr><td {cell_style}>{dim_creator.html_summary()}</td></tr>\n"
             )
         output.write("</table>\n")
         output.write("</li>\n")
@@ -909,7 +910,7 @@ class ArrayCreator:
         output.write("<table>\n")
         for attr_creator in self._attr_creators.values():
             output.write(
-                f'<tr><td style="text-align: left;">{attr_creator.html_summary()}</td></tr>\n'
+                f"<tr><td {cell_style}>{attr_creator.html_summary()}</td></tr>\n"
             )
         output.write("</table>\n")
         output.write("</li>\n")
@@ -917,21 +918,19 @@ class ArrayCreator:
         output.write("Array Properties\n")
         output.write(
             f"<table>\n"
-            f'<tr><td style="text-align: left;">cell_order={self.cell_order}</td></tr>\n'
-            f'<tr><td style="text-align: left;">tile_order={self.tile_order}</td></tr>\n'
-            f'<tr><td style="text-align: left;">capacity={self.capacity}</td></tr>\n'
-            f'<tr><td style="text-align: left;">sparse={self.sparse}</td></tr>\n'
+            f"<tr><td {cell_style}>cell_order={self.cell_order}</td></tr>\n"
+            f"<tr><td {cell_style}>tile_order={self.tile_order}</td></tr>\n"
+            f"<tr><td {cell_style}>capacity={self.capacity}</td></tr>\n"
+            f"<tr><td {cell_style}>sparse={self.sparse}</td></tr>\n"
         )
         if self.sparse:
             output.write(
-                f'<tr><td style="text-align: left;">allows_duplicates'
+                f"<tr><td {cell_style}>allows_duplicates"
                 f"={self.allows_duplicates}</td></tr>\n"
             )
-        if self.coords_filters is not None:
-            output.write(
-                f'<tr><td style="text-align: left;">coords_filters='
-                f"{self.coords_filters}</td></tr>\n"
-            )
+        output.write(
+            f"<tr><td {cell_style}>coords_filters={self.coords_filters}</td></tr>\n"
+        )
         output.write("</table>\n")
         output.write("</li>\n")
         output.write("</ul>\n")

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -98,6 +98,32 @@ class DataspaceCreator:
             output.write("DataspaceCreator()")
         return output.getvalue()
 
+    def _repr_html_(self):
+        output = StringIO()
+        output.write("<section>\n")
+        output.write("<h4>DataspaceCreator</h4>\n")
+        output.write("<ul>\n")
+        output.write("<li>\n")
+        output.write("Shared Dimensions\n")
+        if self._dims:
+            output.write("<p>\n<table>\n")
+            for dim_name, dim in self._dims.items():
+                output.write(f"<tr><th>'{dim_name}':  {repr(dim)}</th></tr>\n")
+            output.write("</table>\n</p>\n")
+            output.write("</details>\n")
+        output.write("</li>\n")
+        output.write("<li>\n")
+        output.write("Array Creators\n")
+        for array_name, array_creator in self._array_creators.items():
+            output.write("<details>\n")
+            output.write(f"<summary>{array_name}</summary>\n")
+            output.write(f"<p>\n{array_creator.html_summary()}\n</p>\n")
+            output.write("</details>\n")
+        output.write("</li>\n")
+        output.write("</ul>\n")
+        output.write("</section>\n")
+        return output.getvalue()
+
     def _add_shared_dimension(self, dim: SharedDim):
         try:
             self._check_new_dim_name(dim)
@@ -859,6 +885,46 @@ class ArrayCreator:
             attr_name: Name of the attribute that will be removed.
         """
         del self._attr_creators[attr_name]
+
+    def html_summary(self) -> str:
+        output = StringIO()
+        output.write("<ul>\n")
+        output.write("<li>\n")
+        output.write("Domain\n")
+        output.write("<table>\n")
+        for dim_creator in self._dim_creators:
+            output.write(f"<tr><th>{repr(dim_creator)}</th></tr>\n")
+        output.write("</table>\n")
+        output.write("</li>\n")
+        output.write("<li>\n")
+        output.write("Attributes\n")
+        output.write("<table>\n")
+        for attr_creator in self._attr_creators.values():
+            output.write(f"<tr><th>{repr(attr_creator)}</th></tr>\n")
+        output.write("</table>\n")
+        output.write("</li>\n")
+        output.write("<li>\n")
+        output.write("Array Properties\n")
+        output.write(
+            f"<table>\n"
+            f"<tr><th>cell_order</th><th>{self.cell_order}</th></tr>\n"
+            f"<tr><th>tile_order</th><th>{self.tile_order}</th></tr>\n"
+            f"<tr><th>capacity</th><th>{self.capacity}</th></tr>\n"
+            f"<tr><th>sparse</th><th>{self.sparse}</th></tr>\n"
+        )
+        if self.sparse:
+            output.write(
+                f"<tr><th>allows_duplicates</th>"
+                f"<th>{self.allows_duplicates}</th></tr>\n"
+            )
+        if self.coords_filters is not None:
+            output.write(
+                f"<tr><th>coords_filters</th><th>{self.coords_filters}</th></tr>\n"
+            )
+        output.write("</table>\n")
+        output.write("</li>\n")
+        output.write("</ul>\n")
+        return output.getvalue()
 
     def set_attr_properties(self, attr_name: str, **properties):
         """Sets properties for an attribute in the array.

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -1057,12 +1057,7 @@ class AttrCreator:
     filters: Optional[tiledb.FilterList] = None
 
     def __repr__(self):
-        filters_str = ""
-        if self.filters:
-            filters_str = ", filters=FilterList(["
-            for attr_filter in self.filters:
-                filters_str += repr(attr_filter) + ", "
-            filters_str += "])"
+        filters_str = f", filters=FilterList({self.filters})" if self.filters else ""
         return (
             f"AttrCreator(name={self.name}, dtype='{self.dtype!s}', var={self.var}, "
             f"nullable={self.nullable}{filters_str})"
@@ -1070,12 +1065,7 @@ class AttrCreator:
 
     def html_summary(self) -> str:
         """Returns a string HTML summary of the :class:`AttrCreator`."""
-        filters_str = ""
-        if self.filters:
-            filters_str = ", filters=FilterList(["
-            for attr_filter in self.filters:
-                filters_str += repr(attr_filter) + ", "
-            filters_str += "])"
+        filters_str = f", filters=FilterList({self.filters})" if self.filters else ""
         return (
             f" &rarr; tiledb.Attr(name={self.name}, dtype='{self.dtype!s}', "
             f"var={self.var}, nullable={self.nullable}{filters_str})"

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -105,14 +105,13 @@ class DataspaceCreator:
         output.write("<li>\n")
         output.write("Shared Dimensions\n")
         if self._dims:
-            output.write("<p>\n<table>\n")
+            output.write("<table>\n")
             for dim in self._dims.values():
                 output.write(
-                    f"<tr><td align=left>{dim.html_input_summary()} &rarr; "
-                    f"SharedDim({dim.html_output_summary()})</td>\n</tr>\n"
+                    f'<tr><td style="text-align: left;">{dim.html_input_summary()} '
+                    f"&rarr; SharedDim({dim.html_output_summary()})</td>\n</tr>\n"
                 )
-            output.write("</table>\n</p>\n")
-            output.write("</details>\n")
+            output.write("</table>\n")
         output.write("</li>\n")
         output.write("<li>\n")
         output.write("Array Creators\n")
@@ -124,7 +123,7 @@ class DataspaceCreator:
                 f"({', '.join(map(str, array_creator.dim_names))})\n"
             )
             output.write("</summary>\n")
-            output.write(f"<p>\n{array_creator.html_summary()}\n</p>\n")
+            output.write(f"{array_creator.html_summary()}\n")
             output.write("</details>\n")
         output.write("</li>\n")
         output.write("</ul>\n")
@@ -900,7 +899,9 @@ class ArrayCreator:
         output.write("Domain\n")
         output.write("<table>\n")
         for dim_creator in self._dim_creators:
-            output.write(f"<tr><td align=left>{dim_creator.html_summary()}</td></tr>\n")
+            output.write(
+                f'<tr><td style="text-align: left;">{dim_creator.html_summary()}</td></tr>\n'
+            )
         output.write("</table>\n")
         output.write("</li>\n")
         output.write("<li>\n")
@@ -908,7 +909,7 @@ class ArrayCreator:
         output.write("<table>\n")
         for attr_creator in self._attr_creators.values():
             output.write(
-                f"<tr><td align=left>{attr_creator.html_summary()}</td></tr>\n"
+                f'<tr><td style="text-align: left;">{attr_creator.html_summary()}</td></tr>\n'
             )
         output.write("</table>\n")
         output.write("</li>\n")
@@ -916,19 +917,20 @@ class ArrayCreator:
         output.write("Array Properties\n")
         output.write(
             f"<table>\n"
-            f"<tr><td align=left>cell_order={self.cell_order}</td></tr>\n"
-            f"<tr><td align=left>tile_order={self.tile_order}</td></tr>\n"
-            f"<tr><td align=left>capacity={self.capacity}</td></tr>\n"
-            f"<tr><td align=left>sparse={self.sparse}</td></tr>\n"
+            f'<tr><td style="text-align: left;">cell_order={self.cell_order}</td></tr>\n'
+            f'<tr><td style="text-align: left;">tile_order={self.tile_order}</td></tr>\n'
+            f'<tr><td style="text-align: left;">capacity={self.capacity}</td></tr>\n'
+            f'<tr><td style="text-align: left;">sparse={self.sparse}</td></tr>\n'
         )
         if self.sparse:
             output.write(
-                f"<tr><td align=left>allows_duplicates"
+                f'<tr><td style="text-align: left;">allows_duplicates'
                 f"={self.allows_duplicates}</td></tr>\n"
             )
         if self.coords_filters is not None:
             output.write(
-                f"<tr><td align=left>coords_filters={self.coords_filters}</td></tr>\n"
+                f'<tr><td style="text-align: left;">coords_filters='
+                f"{self.coords_filters}</td></tr>\n"
             )
         output.write("</table>\n")
         output.write("</li>\n")

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -108,7 +108,7 @@ class DataspaceCreator:
             output.write("<p>\n<table>\n")
             for dim in self._dims.values():
                 output.write(
-                    f"<tr><td>{dim.html_input_summary()} &rarr; "
+                    f"<tr><td align=left>{dim.html_input_summary()} &rarr; "
                     f"SharedDim({dim.html_output_summary()})</td>\n</tr>\n"
                 )
             output.write("</table>\n</p>\n")
@@ -120,7 +120,7 @@ class DataspaceCreator:
             output.write("<details>\n")
             output.write("<summary>\n")
             output.write(
-                f"{array_creator.__class__.__name__} {array_name}"
+                f"{array_creator.__class__.__name__} <em>{array_name}</em>"
                 f"({', '.join(map(str, array_creator.dim_names))})\n"
             )
             output.write("</summary>\n")
@@ -900,34 +900,35 @@ class ArrayCreator:
         output.write("Domain\n")
         output.write("<table>\n")
         for dim_creator in self._dim_creators:
-            output.write(f"<tr><td>{dim_creator.html_summary()}</td></tr>\n")
+            output.write(f"<tr><td align=left>{dim_creator.html_summary()}</td></tr>\n")
         output.write("</table>\n")
         output.write("</li>\n")
         output.write("<li>\n")
         output.write("Attributes\n")
         output.write("<table>\n")
         for attr_creator in self._attr_creators.values():
-            output.write(f"<tr><td>{attr_creator.html_summary()}</td></tr>\n")
+            output.write(
+                f"<tr><td align=left>{attr_creator.html_summary()}</td></tr>\n"
+            )
         output.write("</table>\n")
         output.write("</li>\n")
         output.write("<li>\n")
         output.write("Array Properties\n")
         output.write(
             f"<table>\n"
-            f"<tr><th>Property</th><th>Value</th></tr>\n"
-            f"<tr><td>cell_order</td><td>{self.cell_order}</td></tr>\n"
-            f"<tr><td>tile_order</td><td>{self.tile_order}</td></tr>\n"
-            f"<tr><td>capacity</td><td>{self.capacity}</td></tr>\n"
-            f"<tr><td>sparse</td><td>{self.sparse}</td></tr>\n"
+            f"<tr><td align=left>cell_order={self.cell_order}</td></tr>\n"
+            f"<tr><td align=left>tile_order={self.tile_order}</td></tr>\n"
+            f"<tr><td align=left>capacity={self.capacity}</td></tr>\n"
+            f"<tr><td align=left>sparse={self.sparse}</td></tr>\n"
         )
         if self.sparse:
             output.write(
-                f"<tr><td>allows_duplicates</td>"
-                f"<td>{self.allows_duplicates}</td></tr>\n"
+                f"<tr><td align=left>allows_duplicates"
+                f"={self.allows_duplicates}</td></tr>\n"
             )
         if self.coords_filters is not None:
             output.write(
-                f"<tr><td>coords_filters</td><td>{self.coords_filters}</td></tr>\n"
+                f"<tr><td align=left>coords_filters={self.coords_filters}</td></tr>\n"
             )
         output.write("</table>\n")
         output.write("</li>\n")

--- a/tiledb/cf/engines/netcdf4_engine.py
+++ b/tiledb/cf/engines/netcdf4_engine.py
@@ -60,9 +60,13 @@ class NetCDFCoordToDimConverter(SharedDim, NetCDFDimConverter):
 
     def __repr__(self):
         return (
-            f"Variable(name={self.input_name}, dtype={self.input_dtype}) -> "
+            f"NetCDFVariable(name={self.input_name}, dtype={self.input_dtype}) -> "
             f"{super().__repr__()}"
         )
+
+    def html_input_summary(self):
+        """Returns a HTML string summarizing the input for the dimension."""
+        return f"NetCDFVariable(name={self.input_name}, dtype={self.input_dtype})"
 
     @classmethod
     def from_netcdf(
@@ -177,9 +181,14 @@ class NetCDFDimToDimConverter(SharedDim, NetCDFDimConverter):
     def __repr__(self):
         size_str = "unlimited" if self.is_unlimited else str(self.input_size)
         return (
-            f"Dimension(name={self.input_name}, size={size_str}) -> "
+            f"NetCDFDimension(name={self.input_name}, size={size_str}) -> "
             f"{super().__repr__()}"
         )
+
+    def html_input_summary(self):
+        """Returns a HTML string summarizing the input for the dimension."""
+        size_str = "unlimited" if self.is_unlimited else str(self.input_size)
+        return f"NetCDFDimension(name={self.input_name}, size={size_str})"
 
     @classmethod
     def from_netcdf(
@@ -272,6 +281,10 @@ class NetCDFScalarDimConverter(SharedDim, NetCDFDimConverter):
     def __repr__(self):
         return f" Scalar dimensions -> {super().__repr__()}"
 
+    def html_input_summary(self):
+        """Returns a string HTML summary."""
+        return "NetCDF empty dimension"
+
     def get_values(
         self, netcdf_group: netCDF4.Dataset, sparse: bool
     ) -> Union[np.ndarray, slice]:
@@ -335,8 +348,14 @@ class NetCDFVariableConverter(AttrCreator):
 
     def __repr__(self):
         return (
-            f"Variable(name={self.input_name}, dtype={self.input_dtype}) -> "
+            f"NetCDFVariable(name={self.input_name}, dtype={self.input_dtype}) -> "
             f"{super().__repr__()}"
+        )
+
+    def html_summary(self):
+        return (
+            f"NetCDFVariable(name={self.input_name}, dtype={self.input_dtype})"
+            f"{super().html_summary()}"
         )
 
     @classmethod
@@ -785,6 +804,17 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             output.write(f"Default NetCDF file: {self.default_input_file}\n")
         if self.default_group_path is not None:
             output.write(f"Deault NetCDF group path: {self.default_group_path}\n")
+        return output.getvalue()
+
+    def _repr_html_(self):
+        output = StringIO()
+        output.write(f"{super()._repr_html_()}\n")
+        output.write("<ul>\n")
+        output.write(f"<li>Default NetCDF file: '{self.default_input_file}'</li>\n")
+        output.write(
+            f"<li>Default NetCDF group path: '{self.default_group_path}'</li>\n"
+        )
+        output.write("</ul>\n")
         return output.getvalue()
 
     def add_array(


### PR DESCRIPTION
Create `_repr_html_` methods for the `GroupSchema`, `DataspaceCreator`, and `NetCDF4ConverterEngine` classes. 