### PR TITLE
add try-except for import tiledb and set available attribute in class

### DIFF
--- a/tiledb/cf/engines/xarray_engine.py
+++ b/tiledb/cf/engines/xarray_engine.py
@@ -30,7 +30,12 @@ from xarray.core.pycompat import integer_types
 from xarray.core.utils import FrozenDict, close_on_error
 from xarray.core.variable import Variable
 
-import tiledb
+try:
+    import tiledb
+
+    has_tiledb = True
+except ModuleNotFoundError:
+    has_tiledb = False
 
 from ..creator import DATA_SUFFIX, INDEX_SUFFIX
 
@@ -397,6 +402,8 @@ class TileDBDataStore(AbstractDataStore):
 
 
 class TileDBBackendEntrypoint(BackendEntrypoint):
+    available = has_tiledb
+
     def open_dataset(
         self,
         filename_or_obj,


### PR DESCRIPTION
I added try-except for importing tiledb and set has_tiledb based on success, then used that to set the `available` attribute in BackendEntrypoint class. 

This resolves an error issue with the recent xarray backends update that checks for the available = True attribute on any backend entrypoint plugged into BACKEND_ENTRYPOINTS when accessed with xr.open_dataset.