### PR TITLE
Refactor Xarray Backend Tests

### DIFF
--- a/tests/engines/xarray_engine/test_plugin.py
+++ b/tests/engines/xarray_engine/test_plugin.py
@@ -1,10 +1,10 @@
 # Copyright 2021 TileDB Inc.
 # Licensed under the MIT License.
 import contextlib
-from typing import Any, Dict, Hashable, Optional
+import types
+from typing import Any, Dict, Hashable
 
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
 from pytest import importorskip
@@ -56,7 +56,10 @@ DATETIME_1D_COORDS: Dict[Hashable, Any] = {
 }
 
 DS_ATTRS: Dict[Hashable, Any] = {"description": "test dataset"}
-DATETIME_1D_DS_ATTRS: Dict[Hashable, Any] = {**DS_ATTRS}
+DATETIME_1D_DS_ATTRS: Dict[Hashable, Any] = {
+    **DS_ATTRS,
+    "rows": {"time reference": np.datetime64("2000-01-01"), "freq": "D"},
+}
 
 SAMPLE_DATASETS: Dict[Hashable, Any] = {
     "simple_1d": xr.Dataset(
@@ -83,30 +86,8 @@ SAMPLE_DATASETS: Dict[Hashable, Any] = {
 }
 
 
-def td_to_str(td):
-    return str(td.astype("timedelta64[ns]").astype(float))
-
-
-TIMEDELTAS = {
-    td_to_str(np.timedelta64(1, "D")): "D",
-    td_to_str(np.timedelta64(1, "W")): "W",
-    td_to_str(np.timedelta64(1, "M")): "M",
-    td_to_str(np.timedelta64(1, "Y")): "Y",
-    td_to_str(np.timedelta64(1, "h")): "h",
-    td_to_str(np.timedelta64(1, "m")): "m",
-    td_to_str(np.timedelta64(1, "s")): "s",
-    td_to_str(np.timedelta64(1, "ms")): "ms",
-    td_to_str(np.timedelta64(1, "us")): "us",
-    td_to_str(np.timedelta64(1, "ns")): "ns",
-    td_to_str(np.timedelta64(1, "ps")): "ps",
-    td_to_str(np.timedelta64(1, "fs")): "fs",
-    td_to_str(np.timedelta64(1, "as")): "as",
-}
-
-
 class TestTDBBackend:
     engine = "tiledb"
-    default_dtype: Any = np.int64
 
     @contextlib.contextmanager
     def open(self, path: str):
@@ -114,7 +95,7 @@ class TestTDBBackend:
             yield ds
 
     def write_tdb_array(
-        self, path: str, data: Dict[Optional[Hashable], Any], metadata: Dict[Hashable, Any] = None
+        self, path: str, data: np.ndarray, metadata: Dict[Hashable, Any] = None
     ):
         with tiledb.open(path, "w") as array:
             array[:] = data
@@ -123,69 +104,28 @@ class TestTDBBackend:
                     array.meta[key] = value
 
     def to_tiledb(self, dataset: xr.Dataset, path: str):  # noqa: C901
-        #  set default int/uint dtype if in dims,
-        #  overwrites itself with last 'iu' dim dtype
-        dtypes = []
-        for dim in dataset.dims.keys():
-            dt = dataset[dim].dtype
-            dtypes.append(dt)
-        for dt in dtypes:
-            if dt.kind in "iu":
-                self.default_dtype = dt
-
         coords = dataset.coords
-        w_dims = ("x", "w", "width", "lon", "lng", "long", "longitude")
-        h_dims = ("y", "h", "height", "lat", "latitude")
-        band_dims = ("band", "bands", "count")
-
+        if "spatial_ref" in coords:
+            print("spatial")
         tdb_dims = []
         for name in coords:
             if name in dataset.dims:
                 coord = coords[name]
-
-                min_value = coord.data[0]
-                max_value = coord.data[-1]
                 dtype = coord.dtype
-
-                is_spatial_ds = False
-                if dataset.attrs and "transform" in dataset.attrs:
-                    is_spatial_ds = True
-                if is_spatial_ds and str(name).lower() in (*w_dims, *h_dims, *band_dims):
-                    min_value = 1
-                    max_value = len(coord.data)
-                    dtype = self.default_dtype
-
                 if dtype.kind not in "iuM":
                     raise NotImplementedError(
                         f"TDB Arrays don't work yet with this dtype coord {dtype}"
                     )
-
+                min_value = coord.data[0]
+                max_value = coord.data[-1]
                 if dtype.kind == "M":
-                    second_value = coord.data[1]
-                    step = second_value - min_value
-                    freq_key = str(step.astype("timedelta64[ns]").astype(float))
-                    assert freq_key in TIMEDELTAS
-                    freq = TIMEDELTAS[freq_key]
-                    date_range = pd.date_range(min_value, max_value, freq=freq)
-                    assert (coord.data == date_range).all()
-
-                    if not dataset.attrs:
-                        dataset.attrs = dict()
-                    if name not in dataset.attrs:
-                        dataset.attrs[name] = dict()
-                    dataset.attrs[name]["time"] = dict(
-                        reference=str(min_value), freq=freq
-                    )
-
-                    min_value = 1
-                    max_value = len(coord.data)
-                    dtype = self.default_dtype
-
-                # test for NetCDF dimension type coord starting at 0
-                if min_value == 0:
-                    min_value, max_value = min_value + 1, max_value + 1
-
-                domain = (min_value, max_value)
+                    domain = (1, len(coord.data))
+                    dtype = np.int32
+                else:
+                    # test for NetCDF dimension type coord starting at 0
+                    if min_value == 0:
+                        min_value, max_value = min_value + 1, max_value + 1
+                    domain = (min_value, max_value)
                 tdb_dim = tiledb.Dim(name=name, domain=domain, dtype=dtype)
                 tdb_dims.append(tdb_dim)
 
@@ -193,13 +133,17 @@ class TestTDBBackend:
 
         data_vars = []
         data = dict()
+        vars_attrs = dict()
         for var in dataset.data_vars:
             var = dataset[var]
             data_var = tiledb.Attr(name=var.name, dtype=var.dtype)
             data_vars.append(data_var)
             data[var.name] = var.data
+            vars_attrs[var.name] = var.attrs
 
         schema = tiledb.ArraySchema(domain=dom, attrs=data_vars, sparse=False)
+
+        data = list(data.values())[0]
 
         if tiledb.array_exists(path):
             tiledb.remove(path)
@@ -233,14 +177,9 @@ class TestTDBBackend:
             if isinstance(attrs, dict):
                 for attr_name, value in attrs.items():
                     key = f"{key_prefix}.{attr_name}"
-                    if isinstance(value, dict):
-                        for sub_attr, sub_value in value.items():
-                            sub_key = f"{key}.{sub_attr}"
-                            metadata[sub_key] = sub_value
-                    else:
-                        if isinstance(value, np.datetime64):
-                            value = str(value)
-                        metadata[key] = value
+                    if isinstance(value, np.datetime64):
+                        value = str(value)
+                    metadata[key] = value
             else:
                 metadata[key_prefix] = attrs
 
@@ -287,14 +226,10 @@ class TestTDBBackend:
         self.to_tiledb(expected, path)
         with tiledb.DenseArray(path) as array:
             dims = array.domain
-            dtypes = set(expected[dim.name].dtype.kind for dim in dims)
-            if dtypes.isdisjoint(("M",)):
-                min_vals = [dim.domain[0] for dim in dims]
-                for ii in np.ndindex(array.shape):
-                    jj = list(ii)
-                    for idx in range(len(jj)):
-                        jj[idx] += min_vals[idx]
-                    tdb_ii = tuple(jj)
-                    assert array[tdb_ii]["data"] == expected.data[ii].data
-            else:
-                pass
+            min_vals = [dim.domain[0] for dim in dims]
+            for ii in np.ndindex(array.shape):
+                jj = list(ii)
+                for idx in range(len(jj)):
+                    jj[idx] += min_vals[idx]
+                jj = tuple(jj)
+                assert array[jj]["data"] == expected.data[ii].data

--- a/tests/engines/xarray_engine/test_plugin.py
+++ b/tests/engines/xarray_engine/test_plugin.py
@@ -2,15 +2,17 @@
 # Licensed under the MIT License.
 
 import numpy as np
-
+import pytest
 import xarray as xr
+from pytest import importorskip
 from xarray import Variable, open_dataset
 from xarray.testing import assert_equal
-
-import pytest
-from pytest import importorskip
+from xarray.backends.common import BACKEND_ENTRYPOINTS
 
 tiledb = importorskip("tiledb")
+
+from tiledb_cf.engines.xarray_engine import TileDBBackendEntrypoint
+BACKEND_ENTRYPOINTS["tiledb"] = TileDBBackendEntrypoint
 
 INT_1D_DATA = np.arange(0, 16, dtype=np.int32)
 INT_1D_ATTRS = {"description": "int 1D data var"}
@@ -20,7 +22,10 @@ INT_1D_COORDS = {"rows": np.arange(0, 16, dtype=np.int32)}
 INT_2D_DATA = np.arange(0, 32, dtype=np.int32).reshape(8, 4)
 INT_2D_ATTRS = {"description": "int 2D data var"}
 INT_2D_VAR = Variable(["rows", "cols"], INT_2D_DATA, INT_2D_ATTRS)
-INT_2D_COORDS = {"rows": np.arange(0, 8, dtype=np.int32), "cols": np.arange(0, 4, dtype=np.int32)}
+INT_2D_COORDS = {
+    "rows": np.arange(0, 8, dtype=np.int32),
+    "cols": np.arange(0, 4, dtype=np.int32),
+}
 
 INT_1D_SHIFTED_ATTRS = {"description": "int 1d shifted data var"}
 INT_1D_SHIFTED_VAR = Variable(["rows"], INT_1D_DATA, INT_1D_SHIFTED_ATTRS)
@@ -28,22 +33,49 @@ INT_1D_SHIFTED_COORDS = {"rows": np.arange(5, 21, dtype=np.int32)}
 
 INT_2D_SHIFTED_ATTRS = {"description": "int 2d shifted data var"}
 INT_2D_SHIFTED_VAR = Variable(["rows", "cols"], INT_2D_DATA, INT_2D_SHIFTED_ATTRS)
-INT_2D_SHIFTED_COORDS = {"rows": np.arange(4, 12, dtype=np.int32), "cols": np.arange(1, 5, dtype=np.int32)}
+INT_2D_SHIFTED_COORDS = {
+    "rows": np.arange(4, 12, dtype=np.int32),
+    "cols": np.arange(1, 5, dtype=np.int32),
+}
 
 DATETIME_1D_VAR_ATTRS = {"description": "datetime 1d data var"}
 DATETIME_1D_VAR = Variable(["rows"], INT_1D_DATA, DATETIME_1D_VAR_ATTRS)
-DATETIME_1D_COORDS = {"rows": np.arange(np.datetime64("2000-01-01"), np.datetime64("2000-01-17"), np.timedelta64(1, 'D'))}
+DATETIME_1D_COORDS = {
+    "rows": np.arange(
+        np.datetime64("2000-01-01"), np.datetime64("2000-01-17"), np.timedelta64(1, "D")
+    )
+}
 
 DS_ATTRS = {"description": "test dataset"}
-DATETIME_1D_DS_ATTRS = {**DS_ATTRS, "rows": {"time reference": np.datetime64("2000-01-01"), "freq": "D"}}
+DATETIME_1D_DS_ATTRS = {
+    **DS_ATTRS,
+    "rows": {"time reference": np.datetime64("2000-01-01"), "freq": "D"},
+}
 
 SAMPLE_DATASETS = {
-    "simple_1d": xr.Dataset(data_vars={"data": INT_1D_VAR}, coords=INT_1D_COORDS, attrs=DS_ATTRS),
-    "simple_2d": xr.Dataset(data_vars={"data": INT_2D_VAR}, coords=INT_2D_COORDS, attrs=DS_ATTRS),
-    "1d_shifted": xr.Dataset(data_vars={"data": INT_1D_SHIFTED_VAR}, coords=INT_1D_SHIFTED_COORDS, attrs=DS_ATTRS),
-    "2d_shifted": xr.Dataset(data_vars={"data": INT_2D_SHIFTED_VAR}, coords=INT_2D_SHIFTED_COORDS, attrs=DS_ATTRS),
-    "1d_datetime": xr.Dataset(data_vars={"data": DATETIME_1D_VAR}, coords=DATETIME_1D_COORDS, attrs=DATETIME_1D_DS_ATTRS)
+    "simple_1d": xr.Dataset(
+        data_vars={"data": INT_1D_VAR}, coords=INT_1D_COORDS, attrs=DS_ATTRS
+    ),
+    "simple_2d": xr.Dataset(
+        data_vars={"data": INT_2D_VAR}, coords=INT_2D_COORDS, attrs=DS_ATTRS
+    ),
+    "1d_shifted": xr.Dataset(
+        data_vars={"data": INT_1D_SHIFTED_VAR},
+        coords=INT_1D_SHIFTED_COORDS,
+        attrs=DS_ATTRS,
+    ),
+    "2d_shifted": xr.Dataset(
+        data_vars={"data": INT_2D_SHIFTED_VAR},
+        coords=INT_2D_SHIFTED_COORDS,
+        attrs=DS_ATTRS,
+    ),
+    "1d_datetime": xr.Dataset(
+        data_vars={"data": DATETIME_1D_VAR},
+        coords=DATETIME_1D_COORDS,
+        attrs=DATETIME_1D_DS_ATTRS,
+    ),
 }
+
 
 class TestTDBBackend:
     engine = "tiledb"
@@ -53,80 +85,104 @@ class TestTDBBackend:
             ds_obj = ds
         return ds_obj
 
+    def write_tdb_array(self, path, data, metadata):
+        with tiledb.open(path, "w") as array:
+            array[:] = data
+            for key, value in metadata.items():
+                array.meta[key] = value
+
     def to_tiledb(self, dataset, path):
-        tdb_dims = []
         coords = dataset.coords
-        coords_attrs = dict()
+
+        tdb_dims = []
         for name in coords:
             if name in dataset.dims:
-                if dataset.attrs.get(name) is not None:
-                    coords_attrs[name] = dataset.attrs[name]
                 coord = coords[name]
                 dtype = coord.dtype
-                if dtype.kind not in 'iuM':
-                    raise NotImplementedError(f"TDB Arrays don't work yet with this dtype coord {dtype}")
+                if dtype.kind not in "iuM":
+                    raise NotImplementedError(
+                        f"TDB Arrays don't work yet with this dtype coord {dtype}"
+                    )
                 min_value = coord.data[0]
                 max_value = coord.data[-1]
                 if dtype.kind == "M":
                     domain = (1, len(coord.data))
                     dtype = np.int32
                 else:
-                    domain = (min_value + 1, max_value + 1)
+                    # test for NetCDF dimension type coord starting at 0
+                    if min_value == 0:
+                        min_value, max_value = min_value + 1, max_value + 1
+                    domain = (min_value, max_value)
                 tdb_dim = tiledb.Dim(name=name, domain=domain, dtype=dtype)
                 tdb_dims.append(tdb_dim)
-        tdb_attrs = []
+
+        dom = tiledb.Domain(*tdb_dims)
+
+        data_vars = []
         data = dict()
         vars_attrs = dict()
         for var in dataset.data_vars:
             var = dataset[var]
-            tdb_attr = tiledb.Attr(name=var.name, dtype=var.dtype)
-            tdb_attrs.append(tdb_attr)
+            data_var = tiledb.Attr(name=var.name, dtype=var.dtype)
+            data_vars.append(data_var)
             data[var.name] = var.data
             vars_attrs[var.name] = var.attrs
 
-        dom = tiledb.Domain(*tdb_dims)
-        schema = tiledb.ArraySchema(domain=dom, attrs=tdb_attrs, sparse=False)
+        schema = tiledb.ArraySchema(domain=dom, attrs=data_vars, sparse=False)
+
+        data = list(data.values())[0]
+
         if tiledb.array_exists(path):
             tiledb.remove(path)
         tiledb.DenseArray.create(path, schema)
-        with tiledb.DenseArray(path, "w") as array:
-            # only one data attr works for now
-            array[:] = list(data.values())[0]
-            for key, value in dataset.attrs.items():
-                if key not in dataset.dims and key not in dataset.data_vars:
-                    array.meta[key] = value
-            for var_name, var_attrs in vars_attrs.items():
-                for key, value in var_attrs.items():
-                    array_key = f"__tiledb_attr.{var_name}.{key}"
-                    array.meta[array_key] = value
-            for dim_name, dim_attrs in coords_attrs.items():
-                for key, value in dim_attrs.items():
-                    array_key = f"__tiledb_dim.{dim_name}.{key}"
-                    if isinstance(value, tuple) or isinstance(value, list):
-                        value = "".join(value)
-                    if isinstance(value, np.datetime64):
-                        value = str(value)
-                    array.meta[array_key] = value
+
+        metadata = dict()
+
+        for key, value in dataset.attrs.items():
+            if key not in dataset.dims and key not in dataset.data_vars:
+                metadata[key] = value
+            elif key in dataset.dims:
+                if isinstance(value, dict):
+                    for k, v in value.items():
+                        array_key = f"__tiledb_dim.{key}.{k}"
+                        if isinstance(v, np.datetime64):
+                            v = str(v)
+                        metadata[array_key] = v
+                else:
+                    array_key = f"__tiledv_dim.{key}"
+                    metadata[array_key] = value
+            elif key in dataset.data_vars:
+                if isinstance(value, dict):
+                    for k, v in value.items():
+                        array_key = f"__tiledb_attr.{key}.{k}"
+                        metadata[array_key] = v
+                else:
+                    array_key = f"__tiledv_attr.{key}"
+                    metadata[array_key] = value
+
+        self.write_tdb_array(path, data, metadata)
+
         with tiledb.DenseArray(path) as array:
-            print(array.schema, dict(array.meta))
+            schema = array.schema
+            meta = array.meta
+        return schema, meta
 
     def roundtrip(self, dataset, path):
         self.to_tiledb(dataset, path)
         return self.open(path)
 
-    @pytest.mark.parametrize(
-        "ds_name, expected",
-        SAMPLE_DATASETS.items()
-    )
+    @pytest.mark.parametrize("ds_name, expected", SAMPLE_DATASETS.items())
+    def test_totiledb(self, ds_name, expected, tmpdir):
+        path = f"{tmpdir}/{ds_name}"
+        print(self.to_tiledb(expected, path))
+
+    @pytest.mark.parametrize("ds_name, expected", SAMPLE_DATASETS.items())
     def test_datasets(self, ds_name, expected, tmpdir):
         path = f"{tmpdir}/{ds_name}"
         result = self.roundtrip(expected, path)
         assert_equal(result, expected)
 
-    @pytest.mark.parametrize(
-        "ds_name, expected",
-        SAMPLE_DATASETS.items()
-    )
+    @pytest.mark.parametrize("ds_name, expected", SAMPLE_DATASETS.items())
     def test_tdb_xarray_indexing_match(self, ds_name, expected, tmpdir):
         path = f"{tmpdir}/{ds_name}"
         self.to_tiledb(expected, path)
@@ -138,5 +194,4 @@ class TestTDBBackend:
                 for idx in range(len(jj)):
                     jj[idx] += min_vals[idx]
                 jj = tuple(jj)
-                assert (array[jj]["data"] == expected.data[ii].data)
-
+                assert array[jj]["data"] == expected.data[ii].data

--- a/tests/engines/xarray_engine/test_plugin.py
+++ b/tests/engines/xarray_engine/test_plugin.py
@@ -2,211 +2,141 @@
 # Licensed under the MIT License.
 
 import numpy as np
+
+import xarray as xr
+from xarray import Variable, open_dataset
+from xarray.testing import assert_equal
+
 import pytest
+from pytest import importorskip
 
-import tiledb
+tiledb = importorskip("tiledb")
 
-xr = pytest.importorskip("xarray")
+INT_1D_DATA = np.arange(0, 16, dtype=np.int32)
+INT_1D_ATTRS = {"description": "int 1D data var"}
+INT_1D_VAR = Variable(["rows"], INT_1D_DATA, INT_1D_ATTRS)
+INT_1D_COORDS = {"rows": np.arange(0, 16, dtype=np.int32)}
 
+INT_2D_DATA = np.arange(0, 32, dtype=np.int32).reshape(8, 4)
+INT_2D_ATTRS = {"description": "int 2D data var"}
+INT_2D_VAR = Variable(["rows", "cols"], INT_2D_DATA, INT_2D_ATTRS)
+INT_2D_COORDS = {"rows": np.arange(0, 8, dtype=np.int32), "cols": np.arange(0, 4, dtype=np.int32)}
 
-class TestTileDB:
+INT_1D_SHIFTED_ATTRS = {"description": "int 1d shifted data var"}
+INT_1D_SHIFTED_VAR = Variable(["rows"], INT_1D_DATA, INT_1D_SHIFTED_ATTRS)
+INT_1D_SHIFTED_COORDS = {"rows": np.arange(5, 21, dtype=np.int32)}
 
-    FLOAT_DATA_2D = np.linspace(
-        -1.0, 1.0, num=32, endpoint=True, dtype=np.float64
-    ).reshape(8, 4)
-    INT_DATA_1D = np.arange(0, 16, dtype=np.int64)
-    INT_DATA_2D = np.arange(0, 32, dtype=np.int32).reshape(8, 4)
+INT_2D_SHIFTED_ATTRS = {"description": "int 2d shifted data var"}
+INT_2D_SHIFTED_VAR = Variable(["rows", "cols"], INT_2D_DATA, INT_2D_SHIFTED_ATTRS)
+INT_2D_SHIFTED_COORDS = {"rows": np.arange(4, 12, dtype=np.int32), "cols": np.arange(1, 5, dtype=np.int32)}
 
-    SIMPLE_DATA_ARRAYS = {
-        "simple_example_1d": xr.DataArray(
-            data=INT_DATA_1D,
-            dims="rows",
-        ),
-        "shifted_example_1d": xr.DataArray(
-            data=INT_DATA_1D,
-            dims="rows",
-            coords={"rows": np.arange(-8, 8, dtype=np.int32)},
-        ),
-        "datetime_example_1d": xr.DataArray(
-            data=INT_DATA_1D,
-            dims="rows",
-            coords={
-                "rows": np.arange(
-                    np.datetime64("2000-01-01"), np.datetime64("2000-01-17")
-                )
-            },
-        ),
-        "simple_example_2d": xr.DataArray(
-            data=INT_DATA_2D,
-            dims=["rows", "cols"],
-        ),
-        "shifted_example_2d": xr.DataArray(
-            data=FLOAT_DATA_2D,
-            dims=["rows", "cols"],
-            coords={
-                "rows": np.arange(-3, 5, dtype=np.int32),
-                "cols": np.arange(2, 6, dtype=np.int32),
-            },
-        ),
-    }
+DATETIME_1D_VAR_ATTRS = {"description": "datetime 1d data var"}
+DATETIME_1D_VAR = Variable(["rows"], INT_1D_DATA, DATETIME_1D_VAR_ATTRS)
+DATETIME_1D_COORDS = {"rows": np.arange(np.datetime64("2000-01-01"), np.datetime64("2000-01-17"), np.timedelta64(1, 'D'))}
 
-    simple_examples_1d = [
-        "simple_example_1d",
-        "shifted_example_1d",
-        "datetime_example_1d",
-    ]
+DS_ATTRS = {"description": "test dataset"}
+DATETIME_1D_DS_ATTRS = {**DS_ATTRS, "rows": {"time reference": np.datetime64("2000-01-01"), "freq": "D"}}
 
-    simple_examples_2d = ["simple_example_2d", "shifted_example_2d"]
+SAMPLE_DATASETS = {
+    "simple_1d": xr.Dataset(data_vars={"data": INT_1D_VAR}, coords=INT_1D_COORDS, attrs=DS_ATTRS),
+    "simple_2d": xr.Dataset(data_vars={"data": INT_2D_VAR}, coords=INT_2D_COORDS, attrs=DS_ATTRS),
+    "1d_shifted": xr.Dataset(data_vars={"data": INT_1D_SHIFTED_VAR}, coords=INT_1D_SHIFTED_COORDS, attrs=DS_ATTRS),
+    "2d_shifted": xr.Dataset(data_vars={"data": INT_2D_SHIFTED_VAR}, coords=INT_2D_SHIFTED_COORDS, attrs=DS_ATTRS),
+    "1d_datetime": xr.Dataset(data_vars={"data": DATETIME_1D_VAR}, coords=DATETIME_1D_COORDS, attrs=DATETIME_1D_DS_ATTRS)
+}
 
-    @pytest.fixture(scope="class")
-    def test_directory(self, tmpdir_factory):
-        return str(tmpdir_factory.mktemp("test_data"))
+class TestTDBBackend:
+    engine = "tiledb"
 
-    @pytest.fixture(scope="class")
-    def create_simple_example_data(self, test_directory):
-        # zero-based dimension
-        simple_array_uri = test_directory + "/simple_example_1d"
-        schema = tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(name="rows", domain=(0, 15), tile=4, dtype=np.int32),
-            ),
-            sparse=False,
-            attrs=[tiledb.Attr(name="data", dtype=np.int64)],
-        )
-        tiledb.DenseArray.create(simple_array_uri, schema)
-        with tiledb.DenseArray(simple_array_uri, mode="w") as array:
-            array[:] = {"data": self.INT_DATA_1D}
-        # shifted dimension (with negative values)
-        simple_array_uri = test_directory + "/shifted_example_1d"
-        schema = tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(name="rows", domain=(-8, 7), tile=4, dtype=np.int32),
-            ),
-            sparse=False,
-            attrs=[tiledb.Attr(name="data", dtype=np.int64)],
-        )
-        tiledb.DenseArray.create(simple_array_uri, schema)
-        with tiledb.DenseArray(simple_array_uri, mode="w") as array:
-            array[:] = {"data": self.INT_DATA_1D}
-        # datetime dimension
-        datetime_uri = test_directory + "/datetime_example_1d"
-        schema = tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(
-                    name="rows",
-                    domain=(
-                        np.datetime64("2000-01-01", "D"),
-                        np.datetime64("2000-01-16", "D"),
-                    ),
-                    tile=np.timedelta64(4, "D"),
-                    dtype=np.datetime64("", "D"),
-                ),
-            ),
-            attrs=[tiledb.Attr(name="data", dtype=np.int64)],
-        )
-        tiledb.DenseArray.create(datetime_uri, schema)
-        with tiledb.DenseArray(datetime_uri, mode="w") as array:
-            array[:] = {"data": self.INT_DATA_1D}
-        # simple example 2d
-        array_uri = test_directory + "/simple_example_2d"
-        schema = tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(name="rows", domain=(0, 7), tile=4, dtype=np.int32),
-                tiledb.Dim(name="cols", domain=(0, 3), tile=4, dtype=np.int32),
-            ),
-            sparse=False,
-            attrs=[tiledb.Attr(name="data", dtype=np.int32)],
-        )
-        tiledb.DenseArray.create(array_uri, schema)
-        with tiledb.DenseArray(array_uri, mode="w") as array:
-            array[:, :] = {"data": self.INT_DATA_2D}
-        # shifted example 2d
-        array_uri = test_directory + "/shifted_example_2d"
-        schema = tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(name="rows", domain=(-3, 4), tile=4, dtype=np.int32),
-                tiledb.Dim(name="cols", domain=(2, 5), tile=4, dtype=np.int32),
-            ),
-            sparse=False,
-            attrs=[tiledb.Attr(name="data", dtype=np.float64)],
-        )
-        tiledb.DenseArray.create(array_uri, schema)
-        with tiledb.DenseArray(array_uri, mode="w") as array:
-            array[:, :] = {"data": self.FLOAT_DATA_2D}
+    def open(self, path):
+        with open_dataset(path, engine=self.engine) as ds:
+            ds_obj = ds
+        return ds_obj
 
-    @pytest.fixture(scope="function")
-    def simple_data_arrays(self, test_directory, create_simple_example_data, request):
-        name = request.param
-        array_uri = test_directory + "/" + name
-        dataset = xr.open_dataset(array_uri, engine="tiledb")
-        return dataset["data"], self.SIMPLE_DATA_ARRAYS[name]
+    def to_tiledb(self, dataset, path):
+        tdb_dims = []
+        coords = dataset.coords
+        coords_attrs = dict()
+        for name in coords:
+            if name in dataset.dims:
+                if dataset.attrs.get(name) is not None:
+                    coords_attrs[name] = dataset.attrs[name]
+                coord = coords[name]
+                dtype = coord.dtype
+                if dtype.kind not in 'iuM':
+                    raise NotImplementedError(f"TDB Arrays don't work yet with this dtype coord {dtype}")
+                min_value = coord.data[0]
+                max_value = coord.data[-1]
+                if dtype.kind == "M":
+                    domain = (1, len(coord.data))
+                    dtype = np.int32
+                else:
+                    domain = (min_value + 1, max_value + 1)
+                tdb_dim = tiledb.Dim(name=name, domain=domain, dtype=dtype)
+                tdb_dims.append(tdb_dim)
+        tdb_attrs = []
+        data = dict()
+        vars_attrs = dict()
+        for var in dataset.data_vars:
+            var = dataset[var]
+            tdb_attr = tiledb.Attr(name=var.name, dtype=var.dtype)
+            tdb_attrs.append(tdb_attr)
+            data[var.name] = var.data
+            vars_attrs[var.name] = var.attrs
 
-    def test_open_multidim_dataset(self, create_tiledb_example):
-        uri, expected = create_tiledb_example
-        dataset = xr.open_dataset(uri, engine="tiledb")
-        xr.testing.assert_allclose(dataset, expected)
+        dom = tiledb.Domain(*tdb_dims)
+        schema = tiledb.ArraySchema(domain=dom, attrs=tdb_attrs, sparse=False)
+        if tiledb.array_exists(path):
+            tiledb.remove(path)
+        tiledb.DenseArray.create(path, schema)
+        with tiledb.DenseArray(path, "w") as array:
+            # only one data attr works for now
+            array[:] = list(data.values())[0]
+            for key, value in dataset.attrs.items():
+                if key not in dataset.dims and key not in dataset.data_vars:
+                    array.meta[key] = value
+            for var_name, var_attrs in vars_attrs.items():
+                for key, value in var_attrs.items():
+                    array_key = f"__tiledb_attr.{var_name}.{key}"
+                    array.meta[array_key] = value
+            for dim_name, dim_attrs in coords_attrs.items():
+                for key, value in dim_attrs.items():
+                    array_key = f"__tiledb_dim.{dim_name}.{key}"
+                    if isinstance(value, tuple) or isinstance(value, list):
+                        value = "".join(value)
+                    if isinstance(value, np.datetime64):
+                        value = str(value)
+                    array.meta[array_key] = value
+        with tiledb.DenseArray(path) as array:
+            print(array.schema, dict(array.meta))
 
-    def test_open_multidim_dataset_guess_engine(self, create_tiledb_example):
-        uri, expected = create_tiledb_example
-        dataset = xr.open_dataset(uri)
-        xr.testing.assert_allclose(dataset, expected)
+    def roundtrip(self, dataset, path):
+        self.to_tiledb(dataset, path)
+        return self.open(path)
 
-    @pytest.mark.parametrize("simple_data_arrays", simple_examples_1d, indirect=True)
-    def test_basic_indexing_1D(self, simple_data_arrays):
-        (result, expected) = simple_data_arrays
-        for index in range(expected.size):
-            xr.testing.assert_allclose(result[index], expected[index])
-            xr.testing.assert_allclose(result[-1 - index], expected[-1 - index])
-
-    @pytest.mark.parametrize("simple_data_arrays", simple_examples_1d, indirect=True)
     @pytest.mark.parametrize(
-        "index",
-        [
-            -5,
-            slice(None),
-            slice(0, 5),
-            slice(0, 5, 1),
-            slice(None, 5, 1),
-            slice(5, None, 1),
-            slice(5, 0, -2),
-            slice(1, 1),
-            np.array([0, 5, 3, 2, 1]),
-            np.array([-1, -5, -3, -2, -15]),
-            np.array([0, 0, 2, 2, 1, 3]),
-        ],
+        "ds_name, expected",
+        SAMPLE_DATASETS.items()
     )
-    def test_indexing_array_1D(self, simple_data_arrays, index):
-        (tiledb_data_array, xarray_data_array) = simple_data_arrays
-        xr.testing.assert_allclose(tiledb_data_array[index], xarray_data_array[index])
+    def test_datasets(self, ds_name, expected, tmpdir):
+        path = f"{tmpdir}/{ds_name}"
+        result = self.roundtrip(expected, path)
+        assert_equal(result, expected)
 
-    @pytest.mark.parametrize("simple_data_arrays", simple_examples_2d, indirect=True)
     @pytest.mark.parametrize(
-        "index1, index2",
-        [
-            (0, 0),
-            (1, 2),
-            (-5, 2),
-            (slice(None), slice(None)),
-            (slice(1, 8, 2), slice(0, 3)),
-            (slice(1, 1), slice(None)),
-            (slice(1, 1), 0),
-            (np.array([0, 1, 2]), 1),
-            (slice(1, 8, 2), np.array([0, 1, 2])),
-            (1, np.array([-1, -2])),
-            (np.array([0, 0, 2, 2]), np.array([1, 1, 3])),
-            (1, np.array([])),
-        ],
+        "ds_name, expected",
+        SAMPLE_DATASETS.items()
     )
-    def test_indexing_array_2D(self, simple_data_arrays, index1, index2):
-        (tiledb_data_array, xarray_data_array) = simple_data_arrays
-        xr.testing.assert_allclose(
-            tiledb_data_array[index1, index2],
-            xarray_data_array[index1, index2],
-        )
+    def test_tdb_xarray_indexing_match(self, ds_name, expected, tmpdir):
+        path = f"{tmpdir}/{ds_name}"
+        self.to_tiledb(expected, path)
+        with tiledb.DenseArray(path) as array:
+            dims = array.domain
+            min_vals = [dim.domain[0] for dim in dims]
+            for ii in np.ndindex(array.shape):
+                jj = list(ii)
+                for idx in range(len(jj)):
+                    jj[idx] += min_vals[idx]
+                jj = tuple(jj)
+                assert (array[jj]["data"] == expected.data[ii].data)
 
-    @pytest.mark.parametrize("simple_data_arrays", simple_examples_2d, indirect=True)
-    def test_indexing_array_nested_2D(self, simple_data_arrays):
-        (tiledb_data_array, xarray_data_array) = simple_data_arrays
-        result = tiledb_data_array[[0, 2, 2], [1, 3]][[0, 0, 2], 1]
-        expected = xarray_data_array[[0, 2, 2], [1, 3]][[0, 0, 2], 1]
-        xr.testing.assert_allclose(result, expected)

--- a/tests/engines/xarray_engine/test_plugin.py
+++ b/tests/engines/xarray_engine/test_plugin.py
@@ -105,7 +105,8 @@ class TestTDBBackend:
 
     def to_tiledb(self, dataset: xr.Dataset, path: str):  # noqa: C901
         coords = dataset.coords
-
+        if "spatial_ref" in coords:
+            print("spatial")
         tdb_dims = []
         for name in coords:
             if name in dataset.dims:

--- a/tests/engines/xarray_engine/test_plugin.py
+++ b/tests/engines/xarray_engine/test_plugin.py
@@ -177,9 +177,11 @@ class TestTDBBackend:
 
         self.write_tdb_array(path, data, metadata)
 
+    @contextlib.contextmanager
     def roundtrip(self, dataset, path):
         self.to_tiledb(dataset, path)
-        return self.open(path)
+        with self.open(path) as ds:
+            yield ds
 
     @pytest.mark.parametrize("ds_name, expected", SAMPLE_DATASETS.items())
     def test_totiledb(self, ds_name, expected, tmpdir):

--- a/tests/engines/xarray_engine/test_plugin.py
+++ b/tests/engines/xarray_engine/test_plugin.py
@@ -1,10 +1,10 @@
 # Copyright 2021 TileDB Inc.
 # Licensed under the MIT License.
 import contextlib
-import types
-from typing import Any, Dict, Hashable
+from typing import Any, Dict, Hashable, Optional
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 from pytest import importorskip
@@ -56,10 +56,7 @@ DATETIME_1D_COORDS: Dict[Hashable, Any] = {
 }
 
 DS_ATTRS: Dict[Hashable, Any] = {"description": "test dataset"}
-DATETIME_1D_DS_ATTRS: Dict[Hashable, Any] = {
-    **DS_ATTRS,
-    "rows": {"time reference": np.datetime64("2000-01-01"), "freq": "D"},
-}
+DATETIME_1D_DS_ATTRS: Dict[Hashable, Any] = {**DS_ATTRS}
 
 SAMPLE_DATASETS: Dict[Hashable, Any] = {
     "simple_1d": xr.Dataset(
@@ -86,8 +83,30 @@ SAMPLE_DATASETS: Dict[Hashable, Any] = {
 }
 
 
+def td_to_str(td):
+    return str(td.astype("timedelta64[ns]").astype(float))
+
+
+TIMEDELTAS = {
+    td_to_str(np.timedelta64(1, "D")): "D",
+    td_to_str(np.timedelta64(1, "W")): "W",
+    td_to_str(np.timedelta64(1, "M")): "M",
+    td_to_str(np.timedelta64(1, "Y")): "Y",
+    td_to_str(np.timedelta64(1, "h")): "h",
+    td_to_str(np.timedelta64(1, "m")): "m",
+    td_to_str(np.timedelta64(1, "s")): "s",
+    td_to_str(np.timedelta64(1, "ms")): "ms",
+    td_to_str(np.timedelta64(1, "us")): "us",
+    td_to_str(np.timedelta64(1, "ns")): "ns",
+    td_to_str(np.timedelta64(1, "ps")): "ps",
+    td_to_str(np.timedelta64(1, "fs")): "fs",
+    td_to_str(np.timedelta64(1, "as")): "as",
+}
+
+
 class TestTDBBackend:
     engine = "tiledb"
+    default_dtype: Any = np.int64
 
     @contextlib.contextmanager
     def open(self, path: str):
@@ -95,7 +114,7 @@ class TestTDBBackend:
             yield ds
 
     def write_tdb_array(
-        self, path: str, data: np.ndarray, metadata: Dict[Hashable, Any] = None
+        self, path: str, data: Dict[Optional[Hashable], Any], metadata: Dict[Hashable, Any] = None
     ):
         with tiledb.open(path, "w") as array:
             array[:] = data
@@ -104,28 +123,69 @@ class TestTDBBackend:
                     array.meta[key] = value
 
     def to_tiledb(self, dataset: xr.Dataset, path: str):  # noqa: C901
+        #  set default int/uint dtype if in dims,
+        #  overwrites itself with last 'iu' dim dtype
+        dtypes = []
+        for dim in dataset.dims.keys():
+            dt = dataset[dim].dtype
+            dtypes.append(dt)
+        for dt in dtypes:
+            if dt.kind in "iu":
+                self.default_dtype = dt
+
         coords = dataset.coords
-        if "spatial_ref" in coords:
-            print("spatial")
+        w_dims = ("x", "w", "width", "lon", "lng", "long", "longitude")
+        h_dims = ("y", "h", "height", "lat", "latitude")
+        band_dims = ("band", "bands", "count")
+
         tdb_dims = []
         for name in coords:
             if name in dataset.dims:
                 coord = coords[name]
+
+                min_value = coord.data[0]
+                max_value = coord.data[-1]
                 dtype = coord.dtype
+
+                is_spatial_ds = False
+                if dataset.attrs and "transform" in dataset.attrs:
+                    is_spatial_ds = True
+                if is_spatial_ds and str(name).lower() in (*w_dims, *h_dims, *band_dims):
+                    min_value = 1
+                    max_value = len(coord.data)
+                    dtype = self.default_dtype
+
                 if dtype.kind not in "iuM":
                     raise NotImplementedError(
                         f"TDB Arrays don't work yet with this dtype coord {dtype}"
                     )
-                min_value = coord.data[0]
-                max_value = coord.data[-1]
+
                 if dtype.kind == "M":
-                    domain = (1, len(coord.data))
-                    dtype = np.int32
-                else:
-                    # test for NetCDF dimension type coord starting at 0
-                    if min_value == 0:
-                        min_value, max_value = min_value + 1, max_value + 1
-                    domain = (min_value, max_value)
+                    second_value = coord.data[1]
+                    step = second_value - min_value
+                    freq_key = str(step.astype("timedelta64[ns]").astype(float))
+                    assert freq_key in TIMEDELTAS
+                    freq = TIMEDELTAS[freq_key]
+                    date_range = pd.date_range(min_value, max_value, freq=freq)
+                    assert (coord.data == date_range).all()
+
+                    if not dataset.attrs:
+                        dataset.attrs = dict()
+                    if name not in dataset.attrs:
+                        dataset.attrs[name] = dict()
+                    dataset.attrs[name]["time"] = dict(
+                        reference=str(min_value), freq=freq
+                    )
+
+                    min_value = 1
+                    max_value = len(coord.data)
+                    dtype = self.default_dtype
+
+                # test for NetCDF dimension type coord starting at 0
+                if min_value == 0:
+                    min_value, max_value = min_value + 1, max_value + 1
+
+                domain = (min_value, max_value)
                 tdb_dim = tiledb.Dim(name=name, domain=domain, dtype=dtype)
                 tdb_dims.append(tdb_dim)
 
@@ -133,17 +193,13 @@ class TestTDBBackend:
 
         data_vars = []
         data = dict()
-        vars_attrs = dict()
         for var in dataset.data_vars:
             var = dataset[var]
             data_var = tiledb.Attr(name=var.name, dtype=var.dtype)
             data_vars.append(data_var)
             data[var.name] = var.data
-            vars_attrs[var.name] = var.attrs
 
         schema = tiledb.ArraySchema(domain=dom, attrs=data_vars, sparse=False)
-
-        data = list(data.values())[0]
 
         if tiledb.array_exists(path):
             tiledb.remove(path)
@@ -177,9 +233,14 @@ class TestTDBBackend:
             if isinstance(attrs, dict):
                 for attr_name, value in attrs.items():
                     key = f"{key_prefix}.{attr_name}"
-                    if isinstance(value, np.datetime64):
-                        value = str(value)
-                    metadata[key] = value
+                    if isinstance(value, dict):
+                        for sub_attr, sub_value in value.items():
+                            sub_key = f"{key}.{sub_attr}"
+                            metadata[sub_key] = sub_value
+                    else:
+                        if isinstance(value, np.datetime64):
+                            value = str(value)
+                        metadata[key] = value
             else:
                 metadata[key_prefix] = attrs
 
@@ -226,10 +287,14 @@ class TestTDBBackend:
         self.to_tiledb(expected, path)
         with tiledb.DenseArray(path) as array:
             dims = array.domain
-            min_vals = [dim.domain[0] for dim in dims]
-            for ii in np.ndindex(array.shape):
-                jj = list(ii)
-                for idx in range(len(jj)):
-                    jj[idx] += min_vals[idx]
-                jj = tuple(jj)
-                assert array[jj]["data"] == expected.data[ii].data
+            dtypes = set(expected[dim.name].dtype.kind for dim in dims)
+            if dtypes.isdisjoint(("M",)):
+                min_vals = [dim.domain[0] for dim in dims]
+                for ii in np.ndindex(array.shape):
+                    jj = list(ii)
+                    for idx in range(len(jj)):
+                        jj[idx] += min_vals[idx]
+                    tdb_ii = tuple(jj)
+                    assert array[tdb_ii]["data"] == expected.data[ii].data
+            else:
+                pass

--- a/tiledb/cf/engines/xarray_engine.py
+++ b/tiledb/cf/engines/xarray_engine.py
@@ -15,30 +15,26 @@ Example:
 """
 
 from collections import defaultdict
+from typing import Tuple
 
 import numpy as np
-import pandas as pd
-from affine import Affine
-
-from xarray.core import indexing
-from xarray.core.utils import FrozenDict, close_on_error
-from xarray.core.variable import Variable
-from xarray.backends.file_manager import CachingFileManager
-
 from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
     AbstractDataStore,
     BackendArray,
     BackendEntrypoint,
-    _normalize_path,
 )
-
 from xarray.backends.store import StoreBackendEntrypoint
+from xarray.core.indexing import ExplicitIndexer, LazilyIndexedArray
+from xarray.core.pycompat import integer_types
+from xarray.core.utils import FrozenDict, close_on_error
+from xarray.core.variable import Variable
 
 try:
     import tiledb
+
     has_tiledb = True
-except:
+except ModuleNotFoundError:
     has_tiledb = False
 
 from ..creator import DATA_SUFFIX, INDEX_SUFFIX
@@ -48,231 +44,385 @@ _DIM_PREFIX = "__tiledb_dim."
 _COORD_SUFFIX = ".data"
 
 
+class TileDBIndexConverter:
+    """Converter from xarray-style indices to TileDB-style coordinates.
+
+    This class converts the values contained in an xarray ExplicitIndexer tuple to
+    values usable for indexing a TileDB Dimension. The xarray ExplicitIndexer uses
+    standard 0-based integer indices to look-up values in DataArrays and variables;
+    whereas, Tiledb accesses values directly from the dimension coordinates (analogous
+    to looking-up values by "location" in xarray).
+
+    The following is assumed about xarray indices:
+       * An index may be an integer, a slice, or a Numpy array of integer indices.
+       * An integer index or component of an array is such that -size <= value < size.
+         * Non-negative values are a standard zero-based index.
+         * Negative values count backwards from the end of the array with the last value
+           of the array starting at -1.
+    """
+
+    def __init__(self, dim):
+        dtype_kind = dim.dtype.kind
+        if dtype_kind not in ("i", "u", "M"):
+            raise NotImplementedError(
+                f"support for reading TileDB arrays with a dimension of type "
+                f"{dim.dtype} is not implemented"
+            )
+        self.name = dim.name
+        self.dtype = dim.dtype
+        self.min_value = dim.domain[0]
+        self.max_value = dim.domain[1]
+        self.size = dim.size
+        self.shape = dim.shape
+        if dtype_kind == "M":
+            unit, count = np.datetime_data(self.dtype)
+            self.delta_dtype = np.dtype(f"timedelta64[{count}{unit}]")
+        else:
+            self.delta_dtype = self.dtype
+
+    def __getitem__(self, index):
+        """Converts an xarray integer, array, or slice to an index object usable by the
+            TileDB multi_index function.
+
+        Parameters
+        ----------
+        index : Union[int, np.array, slice]
+            An integer index, array of integer indices, or a slice for indexing an
+            xarray dimension.
+
+        Returns
+        -------
+        new_index : Union[self.dtype, List[self.dtype], slice]
+            A value of type `self.dtype`, a list of values, or a slice for indexing a
+            TileDB dimension using mulit_index.
+        """
+        if isinstance(index, integer_types):
+            # Convert xarray index to TileDB dimension coordinate
+            if not -self.size <= index < self.size:
+                raise IndexError(f"index {index} out of bounds for {type(self)}")
+            return self.to_coordinate(index)
+
+        if isinstance(index, slice) and index.step in (1, None):
+            # Convert from index slice to coordinate slice (note that xarray
+            # includes the starting point and excludes the ending point vs. TileDB
+            # multi_index which includes both the staring point and ending point).
+            start, stop = index.start, index.stop
+            return slice(
+                self.to_coordinate(start) if start is not None else None,
+                self.to_coordinate(stop - 1) if stop is not None else None,
+            )
+
+        # Convert slice or array of xarray indices to list of TileDB dimension
+        # coordinates
+        return list(self.to_coordinates(index))
+
+    def to_coordinate(self, index):
+        """Converts an xarray index to a coordinate for the TileDB dimension.
+
+        Parameters
+        ----------
+        index : int
+            An integer index for indexing an xarray dimension.
+
+        Returns
+        -------
+        new_index : self.dtype
+            A `self.dtype` coordinate for indexing a TileDB dimension.
+        """
+        return self._to_delta(index) + (
+            self.min_value if index >= 0 else self.max_value
+        )
+
+    def to_coordinates(self, index):
+        """
+        Converts an xarray-style slice or Numpy array of indices to an array of
+        coordinates for the TileDB dimension.
+
+        Parameters
+        ----------
+        index : Union[slice, np.ndarray]
+            A slice or an array of integer indices for indexing an xarray dimension.
+
+        Returns
+        -------
+        new_index : Union[np.ndarray]
+            An array of `self.dtype` coordinates for indexing a TileDB dimension.
+        """
+        if isinstance(index, slice):
+            # Using range handles negative start/stop, out-of-bounds, and None values.
+            index = range(self.size)[index]
+            start = self.to_coordinate(index.start)
+            stop = self.to_coordinate(index.stop)
+            step = self._to_delta(index.step)
+            return np.arange(start, stop, step, dtype=self.dtype)
+
+        if isinstance(index, np.ndarray):
+            if index.ndim != 1:
+                raise TypeError(
+                    f"invalid indexer array for {type(self)}; input array index must "
+                    f"have exactly 1 dimension"
+                )
+            # vectorized version of self.to_coordinate
+            if not ((-self.size <= index).all() and (index < self.size).all()):
+                raise IndexError(f"index {index} out of bounds for {type(self)}")
+            return self._to_delta(index) + np.where(
+                index >= 0, self.min_value, self.max_value
+            )
+
+        raise TypeError(f"unexpected indexer type for {type(self)}")
+
+    def _to_delta(self, i):
+        delta = np.asarray(i, self.delta_dtype)
+        return delta[()] if np.isscalar(i) else delta
+
+
+class TileDBCoordinateWrapper(BackendArray):
+    """A backend array wrapper for TileDB dimensions.
+
+    This class is not intended to accessed directly. Instead it should be used
+    through a :class:`LazilyIndexedArray` object.
+    """
+
+    def __init__(self, index_converter: TileDBIndexConverter):
+        """
+        Parameters
+        ----------
+        index_converter : TileDBIndexConverter
+            Converter from xarray index to the dimension this CoordinateWrapper
+            wraps.
+        """
+        self._converter = index_converter
+
+    def __getitem__(self, indexer: ExplicitIndexer):
+        key = indexer.tuple
+        if len(key) != 1:
+            raise ValueError(
+                f"indexer with {len(key)} cannot be used for variable with 1 dimension"
+            )
+        index = key[0]
+        if isinstance(index, integer_types):
+            return self._converter.to_coordinate(index)
+        return self._converter.to_coordinates(index)
+
+    @property
+    def dtype(self) -> np.dtype:
+        """Data type of the backend array."""
+        return self._converter.dtype
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """Shape of the backend array."""
+        return self._converter.shape
+
+
 class TileDBDenseArrayWrapper(BackendArray):
     """A backend array wrapper for a TileDB attribute.
 
     This class is not intended to accessed directly. Instead it should be used
     through a :class:`LazilyIndexedArray` object.
     """
-    def __init__(self, variable_name, datastore):
 
-        self.datastore = datastore
-        self.variable_name = variable_name
-        tdbarr = self.datastore.ds
-        tdb_attr = tdbarr.attr(self.variable_name)
-        if tdb_attr.isanon:
+    def __init__(self, attr, uri, key, timestamp, index_converters):
+        """
+        Parameters
+        ----------
+        attr : tiledb.Attr
+            The TileDB attribute being wrapped by this routine. Must be one of the
+            attributes in the array at the provided URI.
+        uri : str
+            Uniform Resoure Identifier (URI) for TileDB array. May be a path to a
+            local TileDB array or a URI for a remote resource.
+        key : Optional[str]
+            If not None, the key for accessing the TileDB array at the provided URI.
+        timestamp : Optional[int]
+            If not None, time in milliseconds to open the array at.
+        ctx : Optional[tiledb.Ctx]
+            If not None, a TileDB context manager object.
+        index_converters : Tuple[TileDBIndexConverter, ...]
+            The TileDBIndexConverters needed to convert each xarray index to its
+            corresponding TileDB coordinates.
+        """
+        if attr.isanon:
             raise NotImplementedError(
-                "Support for anonymous TileDB attributes has not been implemented yet"
+                "Support for anonymnous TileDB attributes has not been implemented."
             )
+        self.dtype = attr.dtype
+        self._array_kwargs = {
+            "uri": uri,
+            "mode": "r",
+            "key": key,
+            "timestamp": timestamp,
+            "attr": attr.name,
+        }
+        self._index_converters = index_converters
+        self.shape = tuple(converter.size for converter in index_converters)
 
-        array = self.get_array()
-
-        dtype_kind = array.dtype.kind
-        if dtype_kind not in "iuM":
-            raise NotImplementedError(
-                f"support for reading TileDB arrays with a dimension "
-                f"of type {array.dtype}"
+    def __getitem__(self, indexer: ExplicitIndexer):
+        xarray_indices = indexer.tuple
+        if len(xarray_indices) != len(self._index_converters):
+            raise ValueError(
+                f"key of length {len(xarray_indices)} cannot be used for a TileDB array"
+                f" of length {len(self._index_converters)}"
             )
-
-        self.dtype = array.dtype
-        self.shape = array.shape
-        # might need to add test for datetime dtype and adjust
-
-    def get_array(self):
-        return self.datastore.ds[:][self.variable_name]
-
-    def __getitem__(self, key):
-        array = self.get_array()
-        if isinstance(key, indexing.BasicIndexer):
-            return array[key.tuple]
-        else:
-            raise NotImplementedError("fancy indexing not implemented yet")
-
-
-def parse_var(name):
-    if name.endswith(DATA_SUFFIX):
-        name = name[: -len(DATA_SUFFIX)]
-    elif name.endswith(INDEX_SUFFIX):
-        name = name[: -len(INDEX_SUFFIX)]
-    return name
+        # Compute the shape, collapsing any dimensions with integer input.
+        shape = tuple(
+            len(range(converter.size)[index] if isinstance(index, slice) else index)
+            for index, converter in zip(xarray_indices, self._index_converters)
+            if not isinstance(index, integer_types)
+        )
+        # TileDB multi_index does not except empty arrays/slices. If a dimension is
+        # length zero, return an empty numpy array of the correct length.
+        if 0 in shape:
+            return np.zeros(shape)
+        tiledb_indices = tuple(
+            converter[index]
+            for index, converter in zip(xarray_indices, self._index_converters)
+        )
+        with tiledb.open(**self._array_kwargs) as array:
+            result = array.multi_index[tiledb_indices][self._array_kwargs["attr"]]
+        # Note: TileDB multi_index returns the same number of dimensions as the initial
+        # array. To match the expected xarray output, we need to reshape the result to
+        # remove any dimensions corresponding to scalar-valued input.
+        return result.reshape(shape)
 
 
 class TileDBDataStore(AbstractDataStore):
+    """Data store for reading TileDB arrays."""
 
-    def __init__(self, manager):
-        self._manager = manager
-
-    @classmethod
-    def open(
-        cls,
-        filename,
-        mode="r",
-        tdb_key=None,
+    def __init__(
+        self,
+        uri,
+        key=None,
         timestamp=None,
-        ctx=None,
     ):
-        manager = CachingFileManager(tiledb.open,
-                                     filename,
-                                     # using same mode for manager and tdb
-                                     mode=mode,
-                                     kwargs={
-                                         "mode": mode,
-                                         "key": tdb_key,
-                                         "timestamp": timestamp,
-                                         "ctx": ctx,
-                                     })
-        return cls(manager)
-
-    def _acquire(self, needs_lock=False):
-        with self._manager.acquire_context(needs_lock) as tdbarr:
-            ds = tdbarr
-        return ds
-
-    @property
-    def ds(self):
-        return self._acquire()
-
-    def get_data_var(self, variable_name, metadata):
-        variable_name = parse_var(variable_name)
-        dims = self.get_dimensions()
-        data = indexing.LazilyIndexedArray(
-            TileDBDenseArrayWrapper(variable_name, self)
-        )
-        variable = Variable(dims, data, metadata)
-        return variable
-
-    def get_coord_var(self, dim, metadata):
-        coord_name = parse_var(dim.name)
-        coord_size = dim.size
-        dims = {coord_name: coord_size}
-
-        w_dims = ("x", "w", "width", "lon", "lng", "long", "longitude")
-        h_dims = ("y", "h", "height", "lat", "latitude")
-        band_dims = ("band", "bands", "count")
-
-        coord_data = None
-        if coord_name.lower() in (*w_dims, *h_dims, *band_dims):
-            try:
-                transform = self.ds.meta.get('transform')
-            except:
-                transform = None
-            if transform is not None:
-                # assumes transform is stored as List[float,...]
-                transform = Affine(*transform)
-
-                if coord_name.lower() in w_dims:
-                    coord_data, _ = transform * \
-                                    np.meshgrid(np.arange(coord_size) + 0.5, np.zeros(coord_size) + 0.5)
-                    coord_data = coord_data[0, :]
-
-                elif coord_name.lower() in h_dims:
-                    _, coord_data = transform * \
-                                    np.meshgrid(np.zeros(coord_size) + 0.5, np.arange(coord_size) + 0.5)
-                    coord_data = coord_data[:, 0]
-
-                elif coord_name.lower() in band_dims:
-                    coord_data = np.arange(1, coord_size + 1, dtype=np.int64)
-
-        if coord_data is None:
-            min_value = dim.domain[0]
-            max_value = dim.domain[1]
-            dtype = dim.dtype
-            if metadata and "time" in metadata:
-                start_date = np.datetime64(metadata["time"]["reference"])
-                freq = metadata["time"]["freq"]
-                coord_data = pd.date_range(start_date, periods=dim.size, freq=freq)
-                dtype = f"datetime64[{freq}]"
-            else:
-                # parsing NetCDF dim type that is set up domain(1, len(dim))
-                if min_value == 1:
-                    min_value = 0
-                    max_value = max_value - 1
-                coord_data = np.arange(min_value, max_value + 1, dtype=dtype)
-
-        variable = Variable(dims, coord_data, metadata)
-        return variable
-
-    def get_variables(self):
-        variable_metadata = self.get_variable_metadata()
-        data_vars = {attr.name: self.get_data_var(attr.name,
-                                                  variable_metadata.get(attr.name))
-                     for attr in self.ds.schema}
-        coords_vars = {dim.name: self.get_coord_var(dim,
-                                                    variable_metadata.get(dim.name))
-                       for dim in self.ds.schema.domain}
-        return FrozenDict({**data_vars, **coords_vars})
-
-    def get_attrs(self):
-        meta = self.ds.meta
-        attrs = {
-            key: meta[key]
-            for key in meta.keys()
-            if not key.startswith((_ATTR_PREFIX, _DIM_PREFIX))
-        }
-        return attrs
+        """
+        Parameters
+        ----------
+        uri : str
+            Uniform Resoure Identifier (URI) for TileDB array. May be a path to a
+            local TileDB array or a URI for a remote resource.
+        key : Optional[str]
+            If not None, the key for accessing the TileDB array at the provided URI.
+        timestamp : Optional[int]
+            If not None, time in milliseconds to open the array at.
+        """
+        self._uri = uri
+        self._key = key
+        self._timestamp = timestamp
 
     def get_dimensions(self):
-        dims = {dim.name: dim.size for dim in self.ds.schema.domain}
-        return FrozenDict(dims)
+        """Returns a dictionary of dimension names to sizes."""
+        schema = tiledb.ArraySchema.load(self._uri, key=self._key)
+        return FrozenDict({dim.name: dim.size for dim in schema.domain})
+
+    def get_attrs(self):
+        """Returns a dictionary of metadata stored in the array.
+
+        Note that xarray attributes are roughly equivalent to TileDB metadata. The
+        metadata returned here metadata for the dataset, but excludes encoding data for
+        TileDB and attribute metadata.
+        """
+        with tiledb.open(self._uri, key=self._key, mode="r") as array:
+            attrs = {
+                key: array.meta[key]
+                for key in array.meta.keys()
+                if not key.startswith((_ATTR_PREFIX, _DIM_PREFIX))
+            }
+        return FrozenDict(attrs)
+
+    def get_variables(self):
+        """Returns a dictionary of variables.
+
+        Return a dictionary of variables (by name) stored in the TileDB array. Each
+        variable is generated from a TileDB attributes, TileDB encoding metadata,
+        metadata belonging to the attribute, and the name and size of the dimensions of
+        the array.
+        """
+        variable_metadata = self.get_variable_metadata()
+        schema = tiledb.ArraySchema.load(self._uri, key=self._key)
+        index_converters = tuple(map(TileDBIndexConverter, schema.domain))
+        variables = {}
+        # Add TileDB dimensions as xarray variables (these are the coordinates for the
+        # DataArray) for all dimensions that are not "simple" 0-based integer indexes.
+        for converter in index_converters:
+            if converter.dtype.kind == "M" or converter.min_value:
+                variables[converter.name] = Variable(
+                    {converter.name: converter.size},
+                    LazilyIndexedArray(TileDBCoordinateWrapper(converter)),
+                    variable_metadata.get(converter.name),
+                )
+        # Add TileDB attributes as variables.
+        dims = {indexer.name: indexer.size for indexer in index_converters}
+        for attr in schema:
+            variable_name = attr.name
+            if variable_name.endswith(DATA_SUFFIX):
+                variable_name = variable_name[: -len(DATA_SUFFIX)]
+            elif variable_name.endswith(INDEX_SUFFIX):
+                variable_name = variable_name[: -len(INDEX_SUFFIX)]
+            data = LazilyIndexedArray(
+                TileDBDenseArrayWrapper(
+                    attr,
+                    self._uri,
+                    self._key,
+                    self._timestamp,
+                    index_converters,
+                )
+            )
+            metadata = variable_metadata.get(attr.name)
+            if attr.fill is not None:
+                if metadata is None:
+                    metadata = {"_FillValue": attr.fill}
+                elif metadata.get("_FillValue") is not None:
+                    metadata["_FillValue"] = attr.fill
+            variables[variable_name] = Variable(dims, data, metadata)
+        return FrozenDict(variables)
 
     def get_variable_metadata(self):
+        """Returns a dict of dicts for attribute metadata.
+
+        This uses the convention that attribute and dimension metadata are stored
+        using the convention ``__tiledb_attr.{attribute_name}.{key} = {value}``
+        for attributes and ``__tiledb_dim.{dimension_name}.{key} = {value}`` for
+        dimensions.
+        """
         variable_metadata = defaultdict(dict)
-        meta = self.ds.meta
-        for key, value in meta.items():
-            if key.startswith((_ATTR_PREFIX, _DIM_PREFIX)):
-                last_dot_ix = key.rindex(".")
-                attr_name = key[key.index(".") + 1: last_dot_ix]
-                attr_key = key[last_dot_ix + 1:]
-                if not attr_name:
-                    raise RuntimeError(
-                        f"cant parse attribute metadata '{key}' with "
-                        "missing name or key value"
-                    )
-                # splitting attr_name for x.time metadata for datetime coord
-                key_split = attr_name.split(".")
-                if len(key_split) > 1:
-                    if key_split[0] not in variable_metadata:
-                        variable_metadata[key_split[0]] = dict()
-                    if key_split[1] not in variable_metadata[key_split[0]]:
-                        variable_metadata[key_split[0]][key_split[1]] = dict()
-                    variable_metadata[key_split[0]][key_split[1]][attr_key] = value
-                else:
-                    variable_metadata[attr_name][attr_key] = value
-            else:
-                variable_metadata[key] = value
+        with tiledb.open(self._uri, key=self._key, mode="r") as array:
+            for key in array.meta.keys():
+                if key.startswith((_ATTR_PREFIX, _DIM_PREFIX)):
+                    last_dot_ix = key.rindex(".")
+                    attr_name = key[key.index(".") + 1 : last_dot_ix]
+                    if not attr_name:
+                        raise RuntimeError(
+                            f"cannot parse attribute metadata '{key}' with missing name"
+                            " or key value."
+                        )
+                    attr_key = key[last_dot_ix + 1 :]
+                    variable_metadata[attr_name][attr_key] = array.meta[key]
         return variable_metadata
 
 
 class TileDBBackendEntrypoint(BackendEntrypoint):
-    available = True
-
-    def guess_can_open(self, filename_or_obj):
-        try:
-            return tiledb.object_type(filename_or_obj) == "array"
-        except tiledb.TileDBError:
-            return False
+    available = has_tiledb
 
     def open_dataset(
         self,
         filename_or_obj,
+        *,
         mask_and_scale=True,
         decode_times=True,
-        concat_characters=True,
+        concat_characters=None,
         decode_coords=None,
         drop_variables=None,
         use_cftime=None,
         decode_timedelta=None,
-        mode="r",
-        tdb_key=None,
+        key=None,
         timestamp=None,
-        ctx=None,
     ):
-        filename_or_obj = _normalize_path(filename_or_obj)
-        store = TileDBDataStore.open(filename_or_obj, mode=mode, tdb_key=tdb_key, timestamp=timestamp, ctx=ctx)
+        datastore = TileDBDataStore(filename_or_obj, key, timestamp)
         store_entrypoint = StoreBackendEntrypoint()
-        with close_on_error(store):
-            ds = store_entrypoint.open_dataset(
-                store,
+        with close_on_error(datastore):
+            dataset = store_entrypoint.open_dataset(
+                datastore,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,
                 concat_characters=concat_characters,
@@ -281,7 +431,13 @@ class TileDBBackendEntrypoint(BackendEntrypoint):
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )
-        return ds
+        return dataset
+
+    def guess_can_open(self, filename_or_obj):
+        try:
+            return tiledb.object_type(filename_or_obj) == "array"
+        except tiledb.TileDBError:
+            return False
 
 
 BACKEND_ENTRYPOINTS["tiledb"] = TileDBBackendEntrypoint

--- a/tiledb/cf/engines/xarray_engine.py
+++ b/tiledb/cf/engines/xarray_engine.py
@@ -15,26 +15,30 @@ Example:
 """
 
 from collections import defaultdict
-from typing import Tuple
 
 import numpy as np
+import pandas as pd
+from affine import Affine
+
+from xarray.core import indexing
+from xarray.core.utils import FrozenDict, close_on_error
+from xarray.core.variable import Variable
+from xarray.backends.file_manager import CachingFileManager
+
 from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
     AbstractDataStore,
     BackendArray,
     BackendEntrypoint,
+    _normalize_path,
 )
+
 from xarray.backends.store import StoreBackendEntrypoint
-from xarray.core.indexing import ExplicitIndexer, LazilyIndexedArray
-from xarray.core.pycompat import integer_types
-from xarray.core.utils import FrozenDict, close_on_error
-from xarray.core.variable import Variable
 
 try:
     import tiledb
-
     has_tiledb = True
-except ModuleNotFoundError:
+except:
     has_tiledb = False
 
 from ..creator import DATA_SUFFIX, INDEX_SUFFIX
@@ -44,385 +48,231 @@ _DIM_PREFIX = "__tiledb_dim."
 _COORD_SUFFIX = ".data"
 
 
-class TileDBIndexConverter:
-    """Converter from xarray-style indices to TileDB-style coordinates.
-
-    This class converts the values contained in an xarray ExplicitIndexer tuple to
-    values usable for indexing a TileDB Dimension. The xarray ExplicitIndexer uses
-    standard 0-based integer indices to look-up values in DataArrays and variables;
-    whereas, Tiledb accesses values directly from the dimension coordinates (analogous
-    to looking-up values by "location" in xarray).
-
-    The following is assumed about xarray indices:
-       * An index may be an integer, a slice, or a Numpy array of integer indices.
-       * An integer index or component of an array is such that -size <= value < size.
-         * Non-negative values are a standard zero-based index.
-         * Negative values count backwards from the end of the array with the last value
-           of the array starting at -1.
-    """
-
-    def __init__(self, dim):
-        dtype_kind = dim.dtype.kind
-        if dtype_kind not in ("i", "u", "M"):
-            raise NotImplementedError(
-                f"support for reading TileDB arrays with a dimension of type "
-                f"{dim.dtype} is not implemented"
-            )
-        self.name = dim.name
-        self.dtype = dim.dtype
-        self.min_value = dim.domain[0]
-        self.max_value = dim.domain[1]
-        self.size = dim.size
-        self.shape = dim.shape
-        if dtype_kind == "M":
-            unit, count = np.datetime_data(self.dtype)
-            self.delta_dtype = np.dtype(f"timedelta64[{count}{unit}]")
-        else:
-            self.delta_dtype = self.dtype
-
-    def __getitem__(self, index):
-        """Converts an xarray integer, array, or slice to an index object usable by the
-            TileDB multi_index function.
-
-        Parameters
-        ----------
-        index : Union[int, np.array, slice]
-            An integer index, array of integer indices, or a slice for indexing an
-            xarray dimension.
-
-        Returns
-        -------
-        new_index : Union[self.dtype, List[self.dtype], slice]
-            A value of type `self.dtype`, a list of values, or a slice for indexing a
-            TileDB dimension using mulit_index.
-        """
-        if isinstance(index, integer_types):
-            # Convert xarray index to TileDB dimension coordinate
-            if not -self.size <= index < self.size:
-                raise IndexError(f"index {index} out of bounds for {type(self)}")
-            return self.to_coordinate(index)
-
-        if isinstance(index, slice) and index.step in (1, None):
-            # Convert from index slice to coordinate slice (note that xarray
-            # includes the starting point and excludes the ending point vs. TileDB
-            # multi_index which includes both the staring point and ending point).
-            start, stop = index.start, index.stop
-            return slice(
-                self.to_coordinate(start) if start is not None else None,
-                self.to_coordinate(stop - 1) if stop is not None else None,
-            )
-
-        # Convert slice or array of xarray indices to list of TileDB dimension
-        # coordinates
-        return list(self.to_coordinates(index))
-
-    def to_coordinate(self, index):
-        """Converts an xarray index to a coordinate for the TileDB dimension.
-
-        Parameters
-        ----------
-        index : int
-            An integer index for indexing an xarray dimension.
-
-        Returns
-        -------
-        new_index : self.dtype
-            A `self.dtype` coordinate for indexing a TileDB dimension.
-        """
-        return self._to_delta(index) + (
-            self.min_value if index >= 0 else self.max_value
-        )
-
-    def to_coordinates(self, index):
-        """
-        Converts an xarray-style slice or Numpy array of indices to an array of
-        coordinates for the TileDB dimension.
-
-        Parameters
-        ----------
-        index : Union[slice, np.ndarray]
-            A slice or an array of integer indices for indexing an xarray dimension.
-
-        Returns
-        -------
-        new_index : Union[np.ndarray]
-            An array of `self.dtype` coordinates for indexing a TileDB dimension.
-        """
-        if isinstance(index, slice):
-            # Using range handles negative start/stop, out-of-bounds, and None values.
-            index = range(self.size)[index]
-            start = self.to_coordinate(index.start)
-            stop = self.to_coordinate(index.stop)
-            step = self._to_delta(index.step)
-            return np.arange(start, stop, step, dtype=self.dtype)
-
-        if isinstance(index, np.ndarray):
-            if index.ndim != 1:
-                raise TypeError(
-                    f"invalid indexer array for {type(self)}; input array index must "
-                    f"have exactly 1 dimension"
-                )
-            # vectorized version of self.to_coordinate
-            if not ((-self.size <= index).all() and (index < self.size).all()):
-                raise IndexError(f"index {index} out of bounds for {type(self)}")
-            return self._to_delta(index) + np.where(
-                index >= 0, self.min_value, self.max_value
-            )
-
-        raise TypeError(f"unexpected indexer type for {type(self)}")
-
-    def _to_delta(self, i):
-        delta = np.asarray(i, self.delta_dtype)
-        return delta[()] if np.isscalar(i) else delta
-
-
-class TileDBCoordinateWrapper(BackendArray):
-    """A backend array wrapper for TileDB dimensions.
-
-    This class is not intended to accessed directly. Instead it should be used
-    through a :class:`LazilyIndexedArray` object.
-    """
-
-    def __init__(self, index_converter: TileDBIndexConverter):
-        """
-        Parameters
-        ----------
-        index_converter : TileDBIndexConverter
-            Converter from xarray index to the dimension this CoordinateWrapper
-            wraps.
-        """
-        self._converter = index_converter
-
-    def __getitem__(self, indexer: ExplicitIndexer):
-        key = indexer.tuple
-        if len(key) != 1:
-            raise ValueError(
-                f"indexer with {len(key)} cannot be used for variable with 1 dimension"
-            )
-        index = key[0]
-        if isinstance(index, integer_types):
-            return self._converter.to_coordinate(index)
-        return self._converter.to_coordinates(index)
-
-    @property
-    def dtype(self) -> np.dtype:
-        """Data type of the backend array."""
-        return self._converter.dtype
-
-    @property
-    def shape(self) -> Tuple[int, ...]:
-        """Shape of the backend array."""
-        return self._converter.shape
-
-
 class TileDBDenseArrayWrapper(BackendArray):
     """A backend array wrapper for a TileDB attribute.
 
     This class is not intended to accessed directly. Instead it should be used
     through a :class:`LazilyIndexedArray` object.
     """
+    def __init__(self, variable_name, datastore):
 
-    def __init__(self, attr, uri, key, timestamp, index_converters):
-        """
-        Parameters
-        ----------
-        attr : tiledb.Attr
-            The TileDB attribute being wrapped by this routine. Must be one of the
-            attributes in the array at the provided URI.
-        uri : str
-            Uniform Resoure Identifier (URI) for TileDB array. May be a path to a
-            local TileDB array or a URI for a remote resource.
-        key : Optional[str]
-            If not None, the key for accessing the TileDB array at the provided URI.
-        timestamp : Optional[int]
-            If not None, time in milliseconds to open the array at.
-        ctx : Optional[tiledb.Ctx]
-            If not None, a TileDB context manager object.
-        index_converters : Tuple[TileDBIndexConverter, ...]
-            The TileDBIndexConverters needed to convert each xarray index to its
-            corresponding TileDB coordinates.
-        """
-        if attr.isanon:
+        self.datastore = datastore
+        self.variable_name = variable_name
+        tdbarr = self.datastore.ds
+        tdb_attr = tdbarr.attr(self.variable_name)
+        if tdb_attr.isanon:
             raise NotImplementedError(
-                "Support for anonymnous TileDB attributes has not been implemented."
+                "Support for anonymous TileDB attributes has not been implemented yet"
             )
-        self.dtype = attr.dtype
-        self._array_kwargs = {
-            "uri": uri,
-            "mode": "r",
-            "key": key,
-            "timestamp": timestamp,
-            "attr": attr.name,
-        }
-        self._index_converters = index_converters
-        self.shape = tuple(converter.size for converter in index_converters)
 
-    def __getitem__(self, indexer: ExplicitIndexer):
-        xarray_indices = indexer.tuple
-        if len(xarray_indices) != len(self._index_converters):
-            raise ValueError(
-                f"key of length {len(xarray_indices)} cannot be used for a TileDB array"
-                f" of length {len(self._index_converters)}"
+        array = self.get_array()
+
+        dtype_kind = array.dtype.kind
+        if dtype_kind not in "iuM":
+            raise NotImplementedError(
+                f"support for reading TileDB arrays with a dimension "
+                f"of type {array.dtype}"
             )
-        # Compute the shape, collapsing any dimensions with integer input.
-        shape = tuple(
-            len(range(converter.size)[index] if isinstance(index, slice) else index)
-            for index, converter in zip(xarray_indices, self._index_converters)
-            if not isinstance(index, integer_types)
-        )
-        # TileDB multi_index does not except empty arrays/slices. If a dimension is
-        # length zero, return an empty numpy array of the correct length.
-        if 0 in shape:
-            return np.zeros(shape)
-        tiledb_indices = tuple(
-            converter[index]
-            for index, converter in zip(xarray_indices, self._index_converters)
-        )
-        with tiledb.open(**self._array_kwargs) as array:
-            result = array.multi_index[tiledb_indices][self._array_kwargs["attr"]]
-        # Note: TileDB multi_index returns the same number of dimensions as the initial
-        # array. To match the expected xarray output, we need to reshape the result to
-        # remove any dimensions corresponding to scalar-valued input.
-        return result.reshape(shape)
+
+        self.dtype = array.dtype
+        self.shape = array.shape
+        # might need to add test for datetime dtype and adjust
+
+    def get_array(self):
+        return self.datastore.ds[:][self.variable_name]
+
+    def __getitem__(self, key):
+        array = self.get_array()
+        if isinstance(key, indexing.BasicIndexer):
+            return array[key.tuple]
+        else:
+            raise NotImplementedError("fancy indexing not implemented yet")
+
+
+def parse_var(name):
+    if name.endswith(DATA_SUFFIX):
+        name = name[: -len(DATA_SUFFIX)]
+    elif name.endswith(INDEX_SUFFIX):
+        name = name[: -len(INDEX_SUFFIX)]
+    return name
 
 
 class TileDBDataStore(AbstractDataStore):
-    """Data store for reading TileDB arrays."""
 
-    def __init__(
-        self,
-        uri,
-        key=None,
+    def __init__(self, manager):
+        self._manager = manager
+
+    @classmethod
+    def open(
+        cls,
+        filename,
+        mode="r",
+        tdb_key=None,
         timestamp=None,
+        ctx=None,
     ):
-        """
-        Parameters
-        ----------
-        uri : str
-            Uniform Resoure Identifier (URI) for TileDB array. May be a path to a
-            local TileDB array or a URI for a remote resource.
-        key : Optional[str]
-            If not None, the key for accessing the TileDB array at the provided URI.
-        timestamp : Optional[int]
-            If not None, time in milliseconds to open the array at.
-        """
-        self._uri = uri
-        self._key = key
-        self._timestamp = timestamp
+        manager = CachingFileManager(tiledb.open,
+                                     filename,
+                                     # using same mode for manager and tdb
+                                     mode=mode,
+                                     kwargs={
+                                         "mode": mode,
+                                         "key": tdb_key,
+                                         "timestamp": timestamp,
+                                         "ctx": ctx,
+                                     })
+        return cls(manager)
 
-    def get_dimensions(self):
-        """Returns a dictionary of dimension names to sizes."""
-        schema = tiledb.ArraySchema.load(self._uri, key=self._key)
-        return FrozenDict({dim.name: dim.size for dim in schema.domain})
+    def _acquire(self, needs_lock=False):
+        with self._manager.acquire_context(needs_lock) as tdbarr:
+            ds = tdbarr
+        return ds
 
-    def get_attrs(self):
-        """Returns a dictionary of metadata stored in the array.
+    @property
+    def ds(self):
+        return self._acquire()
 
-        Note that xarray attributes are roughly equivalent to TileDB metadata. The
-        metadata returned here metadata for the dataset, but excludes encoding data for
-        TileDB and attribute metadata.
-        """
-        with tiledb.open(self._uri, key=self._key, mode="r") as array:
-            attrs = {
-                key: array.meta[key]
-                for key in array.meta.keys()
-                if not key.startswith((_ATTR_PREFIX, _DIM_PREFIX))
-            }
-        return FrozenDict(attrs)
+    def get_data_var(self, variable_name, metadata):
+        variable_name = parse_var(variable_name)
+        dims = self.get_dimensions()
+        data = indexing.LazilyIndexedArray(
+            TileDBDenseArrayWrapper(variable_name, self)
+        )
+        variable = Variable(dims, data, metadata)
+        return variable
+
+    def get_coord_var(self, dim, metadata):
+        coord_name = parse_var(dim.name)
+        coord_size = dim.size
+        dims = {coord_name: coord_size}
+
+        w_dims = ("x", "w", "width", "lon", "lng", "long", "longitude")
+        h_dims = ("y", "h", "height", "lat", "latitude")
+        band_dims = ("band", "bands", "count")
+
+        coord_data = None
+        if coord_name.lower() in (*w_dims, *h_dims, *band_dims):
+            try:
+                transform = self.ds.meta.get('transform')
+            except:
+                transform = None
+            if transform is not None:
+                # assumes transform is stored as List[float,...]
+                transform = Affine(*transform)
+
+                if coord_name.lower() in w_dims:
+                    coord_data, _ = transform * \
+                                    np.meshgrid(np.arange(coord_size) + 0.5, np.zeros(coord_size) + 0.5)
+                    coord_data = coord_data[0, :]
+
+                elif coord_name.lower() in h_dims:
+                    _, coord_data = transform * \
+                                    np.meshgrid(np.zeros(coord_size) + 0.5, np.arange(coord_size) + 0.5)
+                    coord_data = coord_data[:, 0]
+
+                elif coord_name.lower() in band_dims:
+                    coord_data = np.arange(1, coord_size + 1, dtype=np.int64)
+
+        if coord_data is None:
+            min_value = dim.domain[0]
+            max_value = dim.domain[1]
+            dtype = dim.dtype
+            if metadata and "time" in metadata:
+                start_date = np.datetime64(metadata["time"]["reference"])
+                freq = metadata["time"]["freq"]
+                coord_data = pd.date_range(start_date, periods=dim.size, freq=freq)
+                dtype = f"datetime64[{freq}]"
+            else:
+                # parsing NetCDF dim type that is set up domain(1, len(dim))
+                if min_value == 1:
+                    min_value = 0
+                    max_value = max_value - 1
+                coord_data = np.arange(min_value, max_value + 1, dtype=dtype)
+
+        variable = Variable(dims, coord_data, metadata)
+        return variable
 
     def get_variables(self):
-        """Returns a dictionary of variables.
-
-        Return a dictionary of variables (by name) stored in the TileDB array. Each
-        variable is generated from a TileDB attributes, TileDB encoding metadata,
-        metadata belonging to the attribute, and the name and size of the dimensions of
-        the array.
-        """
         variable_metadata = self.get_variable_metadata()
-        schema = tiledb.ArraySchema.load(self._uri, key=self._key)
-        index_converters = tuple(map(TileDBIndexConverter, schema.domain))
-        variables = {}
-        # Add TileDB dimensions as xarray variables (these are the coordinates for the
-        # DataArray) for all dimensions that are not "simple" 0-based integer indexes.
-        for converter in index_converters:
-            if converter.dtype.kind == "M" or converter.min_value:
-                variables[converter.name] = Variable(
-                    {converter.name: converter.size},
-                    LazilyIndexedArray(TileDBCoordinateWrapper(converter)),
-                    variable_metadata.get(converter.name),
-                )
-        # Add TileDB attributes as variables.
-        dims = {indexer.name: indexer.size for indexer in index_converters}
-        for attr in schema:
-            variable_name = attr.name
-            if variable_name.endswith(DATA_SUFFIX):
-                variable_name = variable_name[: -len(DATA_SUFFIX)]
-            elif variable_name.endswith(INDEX_SUFFIX):
-                variable_name = variable_name[: -len(INDEX_SUFFIX)]
-            data = LazilyIndexedArray(
-                TileDBDenseArrayWrapper(
-                    attr,
-                    self._uri,
-                    self._key,
-                    self._timestamp,
-                    index_converters,
-                )
-            )
-            metadata = variable_metadata.get(attr.name)
-            if attr.fill is not None:
-                if metadata is None:
-                    metadata = {"_FillValue": attr.fill}
-                elif metadata.get("_FillValue") is not None:
-                    metadata["_FillValue"] = attr.fill
-            variables[variable_name] = Variable(dims, data, metadata)
-        return FrozenDict(variables)
+        data_vars = {attr.name: self.get_data_var(attr.name,
+                                                  variable_metadata.get(attr.name))
+                     for attr in self.ds.schema}
+        coords_vars = {dim.name: self.get_coord_var(dim,
+                                                    variable_metadata.get(dim.name))
+                       for dim in self.ds.schema.domain}
+        return FrozenDict({**data_vars, **coords_vars})
+
+    def get_attrs(self):
+        meta = self.ds.meta
+        attrs = {
+            key: meta[key]
+            for key in meta.keys()
+            if not key.startswith((_ATTR_PREFIX, _DIM_PREFIX))
+        }
+        return attrs
+
+    def get_dimensions(self):
+        dims = {dim.name: dim.size for dim in self.ds.schema.domain}
+        return FrozenDict(dims)
 
     def get_variable_metadata(self):
-        """Returns a dict of dicts for attribute metadata.
-
-        This uses the convention that attribute and dimension metadata are stored
-        using the convention ``__tiledb_attr.{attribute_name}.{key} = {value}``
-        for attributes and ``__tiledb_dim.{dimension_name}.{key} = {value}`` for
-        dimensions.
-        """
         variable_metadata = defaultdict(dict)
-        with tiledb.open(self._uri, key=self._key, mode="r") as array:
-            for key in array.meta.keys():
-                if key.startswith((_ATTR_PREFIX, _DIM_PREFIX)):
-                    last_dot_ix = key.rindex(".")
-                    attr_name = key[key.index(".") + 1 : last_dot_ix]
-                    if not attr_name:
-                        raise RuntimeError(
-                            f"cannot parse attribute metadata '{key}' with missing name"
-                            " or key value."
-                        )
-                    attr_key = key[last_dot_ix + 1 :]
-                    variable_metadata[attr_name][attr_key] = array.meta[key]
+        meta = self.ds.meta
+        for key, value in meta.items():
+            if key.startswith((_ATTR_PREFIX, _DIM_PREFIX)):
+                last_dot_ix = key.rindex(".")
+                attr_name = key[key.index(".") + 1: last_dot_ix]
+                attr_key = key[last_dot_ix + 1:]
+                if not attr_name:
+                    raise RuntimeError(
+                        f"cant parse attribute metadata '{key}' with "
+                        "missing name or key value"
+                    )
+                # splitting attr_name for x.time metadata for datetime coord
+                key_split = attr_name.split(".")
+                if len(key_split) > 1:
+                    if key_split[0] not in variable_metadata:
+                        variable_metadata[key_split[0]] = dict()
+                    if key_split[1] not in variable_metadata[key_split[0]]:
+                        variable_metadata[key_split[0]][key_split[1]] = dict()
+                    variable_metadata[key_split[0]][key_split[1]][attr_key] = value
+                else:
+                    variable_metadata[attr_name][attr_key] = value
+            else:
+                variable_metadata[key] = value
         return variable_metadata
 
 
 class TileDBBackendEntrypoint(BackendEntrypoint):
-    available = has_tiledb
+    available = True
+
+    def guess_can_open(self, filename_or_obj):
+        try:
+            return tiledb.object_type(filename_or_obj) == "array"
+        except tiledb.TileDBError:
+            return False
 
     def open_dataset(
         self,
         filename_or_obj,
-        *,
         mask_and_scale=True,
         decode_times=True,
-        concat_characters=None,
+        concat_characters=True,
         decode_coords=None,
         drop_variables=None,
         use_cftime=None,
         decode_timedelta=None,
-        key=None,
+        mode="r",
+        tdb_key=None,
         timestamp=None,
+        ctx=None,
     ):
-        datastore = TileDBDataStore(filename_or_obj, key, timestamp)
+        filename_or_obj = _normalize_path(filename_or_obj)
+        store = TileDBDataStore.open(filename_or_obj, mode=mode, tdb_key=tdb_key, timestamp=timestamp, ctx=ctx)
         store_entrypoint = StoreBackendEntrypoint()
-        with close_on_error(datastore):
-            dataset = store_entrypoint.open_dataset(
-                datastore,
+        with close_on_error(store):
+            ds = store_entrypoint.open_dataset(
+                store,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,
                 concat_characters=concat_characters,
@@ -431,13 +281,7 @@ class TileDBBackendEntrypoint(BackendEntrypoint):
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )
-        return dataset
-
-    def guess_can_open(self, filename_or_obj):
-        try:
-            return tiledb.object_type(filename_or_obj) == "array"
-        except tiledb.TileDBError:
-            return False
+        return ds
 
 
 BACKEND_ENTRYPOINTS["tiledb"] = TileDBBackendEntrypoint


### PR DESCRIPTION
Refactored the tests to work with xarray dataset samples and set to_tiledb and then open_dataset with our engine for roundtrip to compare expected and result datasets. I also added a test for comparing results from indexing tdb arrays to indexing the xarray dataset. Still needs work on fixtures and edit domain settings and to be built out a bit in general. 