### PR TITLE
tiledb.object_type needs to know the correct context

### DIFF
--- a/tiledb/cf/core.py
+++ b/tiledb/cf/core.py
@@ -633,7 +633,7 @@ class GroupSchema(Mapping):
         vfs = tiledb.VFS(ctx=ctx)
         array_schemas = {}
         for item_uri in vfs.ls(uri):
-            if not tiledb.object_type(item_uri) == "array":
+            if not tiledb.object_type(item_uri, ctx) == "array":
                 continue
             array_name = item_uri.split("/")[-1]
             local_key = _get_array_key(key, array_name)


### PR DESCRIPTION
Closes https://app.clubhouse.io/tiledb-inc/story/10053/reproduce-debug-write-failure-from-tiledb-cf-py-to-azure