### PR TITLE
Deprecate old DataspaceCreator API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,9 +29,13 @@
 * Deprecates `Dataspace.add_array` in favor of `Dataspace.add_array_creator`.
 * Deprecates `Dataspace.add_attr` in favor of `Dataspace.add_attr_creator`.
 * Deprecates `Dataspace.add_dim` in favor of `Dataspace.add_shared_dim`.
+* Deprecates `Dataspace.remove_array` in favor of `Dataspace.remove_array_creator`.
+* Deprecates `Dataspace.remove_attr` in favor of `Dataspace.remove_attr_creator`.
+* Deprecates `Dataspace.remove_dim` in favor of `Dataspace.remove_shared_dim`.
 * Deprecates `Dataspace.array_names`, `Dataspace.dim_names`, and `Dataspace.attr_names`
 * Deprecates `Dataspace.get_array_properties`, `Dataspace.get_attr_properties`, and `Dataspace.get_dim_properties`
 * Deprecates `Dataspace.set_array_properties`, `Dataspace.set_attr_properties`, and `Dataspace.set_dim_properties`
+* Deprecates `Dataspace.rename_array`, `Dataspace.rename_attr`, and `Dataspace.rename_dim`
 
 ## TileDB-CF-Py Release 0.3.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,6 +26,7 @@
 
 * Deprecates `Group.create_virtual` in favor of `VirtualGroup.create`.
 * Deprecates `NetCDF4ConverterEngine.add_scalar_dim_converter` in favor of `NetCDF4ConverterEngine.add_scalar_to_dim_converter`.
+* Deprecates `add_array` in favor of `add_array_creator`.
 
 ## TileDB-CF-Py Release 0.3.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@
 * Deprecates `NetCDF4ConverterEngine.add_scalar_dim_converter` in favor of `NetCDF4ConverterEngine.add_scalar_to_dim_converter`.
 * Deprecates `Dataspace.add_array` in favor of `Dataspace.add_array_creator`.
 * Deprecates `Dataspace.add_attr` in favor of `Dataspace.add_attr_creator`.
+* Deprecates `Dataspace.add_dim` in favor of `Dataspace.add_shared_dim`.
 
 ## TileDB-CF-Py Release 0.3.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,6 +29,8 @@
 * Deprecates `Dataspace.add_array` in favor of `Dataspace.add_array_creator`.
 * Deprecates `Dataspace.add_attr` in favor of `Dataspace.add_attr_creator`.
 * Deprecates `Dataspace.add_dim` in favor of `Dataspace.add_shared_dim`.
+* Deprecates `Dataspace.array_names`, `Dataspace.dim_names`, and `Dataspace.attr_names`
+
 
 ## TileDB-CF-Py Release 0.3.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,7 +30,7 @@
 * Deprecates `Dataspace.add_attr` in favor of `Dataspace.add_attr_creator`.
 * Deprecates `Dataspace.add_dim` in favor of `Dataspace.add_shared_dim`.
 * Deprecates `Dataspace.array_names`, `Dataspace.dim_names`, and `Dataspace.attr_names`
-
+* Deprecates `Dataspace.get_array_properties`, `Dataspace.get_attr_properties`, and `Dataspace.get_dim_properties`
 
 ## TileDB-CF-Py Release 0.3.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,7 +26,8 @@
 
 * Deprecates `Group.create_virtual` in favor of `VirtualGroup.create`.
 * Deprecates `NetCDF4ConverterEngine.add_scalar_dim_converter` in favor of `NetCDF4ConverterEngine.add_scalar_to_dim_converter`.
-* Deprecates `add_array` in favor of `add_array_creator`.
+* Deprecates `Dataspace.add_array` in favor of `Dataspace.add_array_creator`.
+* Deprecates `Dataspace.add_attr` in favor of `Dataspace.add_attr_creator`.
 
 ## TileDB-CF-Py Release 0.3.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@
 * Deprecates `Dataspace.add_dim` in favor of `Dataspace.add_shared_dim`.
 * Deprecates `Dataspace.array_names`, `Dataspace.dim_names`, and `Dataspace.attr_names`
 * Deprecates `Dataspace.get_array_properties`, `Dataspace.get_attr_properties`, and `Dataspace.get_dim_properties`
+* Deprecates `Dataspace.set_array_properties`, `Dataspace.set_attr_properties`, and `Dataspace.set_dim_properties`
 
 ## TileDB-CF-Py Release 0.3.0
 

--- a/tests/creator/test_dataspace_creator.py
+++ b/tests/creator/test_dataspace_creator.py
@@ -101,16 +101,19 @@ class TestDataspaceCreatorExample1:
             assert dataspace_creator.dim_names == {"pressure.index", "temperature"}
 
     def test_get_array_property(self, dataspace_creator):
-        tiles = dataspace_creator.get_array_property("A1", "tiles")
-        assert tiles == (2,)
+        with pytest.warns(DeprecationWarning):
+            tiles = dataspace_creator.get_array_property("A1", "tiles")
+            assert tiles == (2,)
 
     def test_get_attr_property(self, dataspace_creator):
-        dtype = dataspace_creator.get_attr_property("b", "dtype")
-        assert dtype == np.dtype(np.float64)
+        with pytest.warns(DeprecationWarning):
+            dtype = dataspace_creator.get_attr_property("b", "dtype")
+            assert dtype == np.dtype(np.float64)
 
     def test_get_dim_property(self, dataspace_creator):
-        dtype = dataspace_creator.get_dim_property("temperature", "dtype")
-        assert dtype == np.dtype(np.uint64)
+        with pytest.warns(DeprecationWarning):
+            dtype = dataspace_creator.get_dim_property("temperature", "dtype")
+            assert dtype == np.dtype(np.uint64)
 
     def test_to_schema(self, dataspace_creator):
         group_schema = dataspace_creator.to_schema()
@@ -223,9 +226,10 @@ def test_add_dim_name_exists_error():
 
 
 def test_get_property_attr_key_error():
-    creator = DataspaceCreator()
-    with pytest.raises(KeyError):
-        creator.get_attr_property("a1", "nullable")
+    with pytest.warns(DeprecationWarning):
+        creator = DataspaceCreator()
+        with pytest.raises(KeyError):
+            creator.get_attr_property("a1", "nullable")
 
 
 def test_remove_empty_array():
@@ -462,16 +466,16 @@ def test_set_dim_dtype():
     creator = DataspaceCreator()
     creator.add_shared_dim("row", [0, 7], np.int64)
     creator.set_dim_properties("row", dtype=np.float64)
-    dtype = creator.get_dim_property("row", "dtype")
-    assert dtype == np.dtype(np.float64)
+    shared_dim = creator.get_shared_dim("row")
+    assert shared_dim.dtype == np.dtype(np.float64)
 
 
 def test_set_dim_domain():
     creator = DataspaceCreator()
     creator.add_shared_dim("row", [0, 7], np.int64)
     creator.set_dim_properties("row", domain=(1, 8))
-    domain = creator.get_dim_property("row", "domain")
-    assert domain == (1, 8)
+    shared_dim = creator.get_shared_dim("row")
+    assert shared_dim.domain == (1, 8)
 
 
 def test_set_dim_name():
@@ -480,15 +484,6 @@ def test_set_dim_name():
     creator.set_dim_properties("row", name="column")
     shared_dim = creator.get_shared_dim("column")
     assert isinstance(shared_dim, SharedDim)
-
-
-def test_set_dim_dtype_with_array_check():
-    creator = DataspaceCreator()
-    creator.add_shared_dim("row", [0, 7], np.int64)
-    creator.add_array_creator("array1", ("row",))
-    creator.set_dim_properties("row", dtype=np.uint32)
-    dtype = creator.get_dim_property("row", "dtype")
-    assert dtype == np.dtype(np.uint32)
 
 
 def test_set_attr_property_no_attr_err():

--- a/tests/creator/test_dataspace_creator.py
+++ b/tests/creator/test_dataspace_creator.py
@@ -442,7 +442,7 @@ def test_rename_dim_no_merge_error():
         creator.get_shared_dim("col").name = "row"
 
 
-def test_rename_dim_attr_name__in_array_exists_error():
+def test_rename_dim_attr_name_in_array_exists_error():
     creator = DataspaceCreator()
     creator.add_shared_dim("y1", (0, 4), np.int32)
     creator.add_array_creator("A1", ["y1"])

--- a/tests/creator/test_dataspace_creator.py
+++ b/tests/creator/test_dataspace_creator.py
@@ -456,7 +456,8 @@ def test_set_attr_property():
     creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_attr_creator("x1", "A1", np.float64)
-    creator.set_attr_properties("x1", fill=-1)
+    with pytest.warns(DeprecationWarning):
+        creator.set_attr_properties("x1", fill=-1)
     group_schema = creator.to_schema()
     attr_schema = group_schema["A1"].attr(0)
     assert attr_schema.fill == -1
@@ -465,7 +466,8 @@ def test_set_attr_property():
 def test_set_dim_dtype():
     creator = DataspaceCreator()
     creator.add_shared_dim("row", [0, 7], np.int64)
-    creator.set_dim_properties("row", dtype=np.float64)
+    with pytest.warns(DeprecationWarning):
+        creator.set_dim_properties("row", dtype=np.float64)
     shared_dim = creator.get_shared_dim("row")
     assert shared_dim.dtype == np.dtype(np.float64)
 
@@ -473,7 +475,8 @@ def test_set_dim_dtype():
 def test_set_dim_domain():
     creator = DataspaceCreator()
     creator.add_shared_dim("row", [0, 7], np.int64)
-    creator.set_dim_properties("row", domain=(1, 8))
+    with pytest.warns(DeprecationWarning):
+        creator.set_dim_properties("row", domain=(1, 8))
     shared_dim = creator.get_shared_dim("row")
     assert shared_dim.domain == (1, 8)
 
@@ -481,15 +484,17 @@ def test_set_dim_domain():
 def test_set_dim_name():
     creator = DataspaceCreator()
     creator.add_shared_dim("row", [0, 7], np.int64)
-    creator.set_dim_properties("row", name="column")
+    with pytest.warns(DeprecationWarning):
+        creator.set_dim_properties("row", name="column")
     shared_dim = creator.get_shared_dim("column")
     assert isinstance(shared_dim, SharedDim)
 
 
 def test_set_attr_property_no_attr_err():
-    creator = DataspaceCreator()
-    with pytest.raises(KeyError):
-        creator.set_attr_properties("x1", fill=-1)
+    with pytest.warns(DeprecationWarning):
+        creator = DataspaceCreator()
+        with pytest.raises(KeyError):
+            creator.set_attr_properties("x1", fill=-1)
 
 
 def test_dataspace_creator_name():

--- a/tests/creator/test_dataspace_creator.py
+++ b/tests/creator/test_dataspace_creator.py
@@ -14,19 +14,19 @@ class TestDataspaceCreatorExample1:
         creator = DataspaceCreator()
         creator.add_dim("pressure.index", (0, 3), np.uint64)
         creator.add_dim("temperature", (1, 8), np.uint64)
-        creator.add_array("A1", ("pressure.index",))
+        creator.add_array_creator("A1", ("pressure.index",))
         filters = tiledb.FilterList(
             [
                 tiledb.ZstdFilter(level=1),
             ]
         )
-        creator.add_array(
+        creator.add_array_creator(
             "A2",
             ("pressure.index", "temperature"),
             sparse=True,
             dim_filters={"temperature": filters},
         )
-        creator.add_array("A3", ("temperature",))
+        creator.add_array_creator("A3", ("temperature",))
         creator.set_array_properties("A1", tiles=(2,))
         creator.set_array_properties("A2", tiles=(2, 4))
         creator.set_array_properties("A3", tiles=[8])
@@ -165,16 +165,16 @@ def test_create_array_no_array_error():
 def test_array_name_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", (0, 3), np.int64)
-    creator.add_array("array1", ("row",))
+    creator.add_array_creator("array1", ("row",))
     with pytest.raises(ValueError):
-        creator.add_array("array1", ("row",))
+        creator.add_array_creator("array1", ("row",))
 
 
 def test_array_name_reserved_error():
     creator = DataspaceCreator()
     creator.add_dim("row", (0, 3), np.int64)
     with pytest.raises(ValueError):
-        creator.add_array(METADATA_ARRAY_NAME, ("row",))
+        creator.add_array_creator(METADATA_ARRAY_NAME, ("row",))
 
 
 def test_add_attr_no_array_error():
@@ -186,8 +186,8 @@ def test_add_attr_no_array_error():
 def test_add_attr_name_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", (0, 3), np.int64)
-    creator.add_array("array1", ("row",))
-    creator.add_array("array2", ("row",))
+    creator.add_array_creator("array1", ("row",))
+    creator.add_array_creator("array2", ("row",))
     creator.add_attr("attr1", "array1", np.float64)
     with pytest.raises(ValueError):
         creator.add_attr("attr1", "array2", np.float64)
@@ -196,7 +196,7 @@ def test_add_attr_name_exists_error():
 def test_add_attr_dim_name_in_array_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", (0, 3), np.uint64)
-    creator.add_array("array1", ("row",))
+    creator.add_array_creator("array1", ("row",))
     with pytest.raises(ValueError):
         creator.add_attr("row", "array1", np.float64)
 
@@ -204,8 +204,8 @@ def test_add_attr_dim_name_in_array_exists_error():
 def test_add_attr_axis_data_coord_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", (0, 3), np.int64)
-    creator.add_array("array1", ("row",))
-    creator.add_array("array2", ("row",))
+    creator.add_array_creator("array1", ("row",))
+    creator.add_array_creator("array2", ("row",))
     creator.add_attr("attr1", "array1", np.float64)
     with pytest.raises(ValueError):
         creator.add_attr("attr1.data", "array2", np.float64)
@@ -227,7 +227,7 @@ def test_get_property_attr_key_error():
 def test_remove_empty_array():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 10], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     creator.remove_array("A1")
     assert set(creator.array_names) == set()
 
@@ -235,8 +235,8 @@ def test_remove_empty_array():
 def test_remove_array_with_attrs():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 10], np.int64)
-    creator.add_array("A1", ["row"])
-    creator.add_array("A2", ["row"])
+    creator.add_array_creator("A1", ["row"])
+    creator.add_array_creator("A2", ["row"])
     creator.add_attr("x1", "A1", np.float64)
     creator.add_attr("x2", "A1", np.float64)
     creator.add_attr("y1", "A2", np.float64)
@@ -248,8 +248,8 @@ def test_remove_array_with_attrs():
 def test_remove_renamed_array():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 10], np.int64)
-    creator.add_array("A1", ["row"])
-    creator.add_array("A2", ["row"])
+    creator.add_array_creator("A1", ["row"])
+    creator.add_array_creator("A2", ["row"])
     creator.add_attr("x1", "A1", np.float64)
     creator.add_attr("x2", "A1", np.float64)
     creator.add_attr("y1", "A2", np.float64)
@@ -262,12 +262,12 @@ def test_remove_renamed_array():
 def test_remove_attr():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     creator.add_attr("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
     creator.remove_attr("x1")
     assert set(creator.attr_names) == set()
-    creator.add_array("A2", ["row"])
+    creator.add_array_creator("A2", ["row"])
     creator.add_attr("x1", "A2", np.float64)
     assert set(creator.attr_names) == {"x1"}
 
@@ -275,7 +275,7 @@ def test_remove_attr():
 def test_remove_attr_no_attr_error():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     with pytest.raises(KeyError):
         creator.remove_attr("x1")
 
@@ -299,8 +299,8 @@ def test_remove_dim_axis_data():
 def test_remove_dim_in_use_error():
     creator = DataspaceCreator()
     creator.add_dim("row.data", [0.0, 100.0], np.float64)
-    creator.add_array("A1", ["row.data"], sparse=True)
-    creator.add_array("A2", ["row.data"], sparse=True)
+    creator.add_array_creator("A1", ["row.data"], sparse=True)
+    creator.add_array_creator("A2", ["row.data"], sparse=True)
     with pytest.raises(ValueError):
         creator.remove_dim("row.data")
 
@@ -308,7 +308,7 @@ def test_remove_dim_in_use_error():
 def test_rename_array():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     assert set(creator.array_names) == {"A1"}
     creator.rename_array("A1", "B1")
     assert set(creator.array_names) == {"B1"}
@@ -318,7 +318,7 @@ def test_rename_array_with_attrs():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 3], np.int32)
     creator.add_dim("col", [0, 3], np.int32)
-    creator.add_array("A1", ["row", "col"], sparse=True, tiles=[2, 2])
+    creator.add_array_creator("A1", ["row", "col"], sparse=True, tiles=[2, 2])
     creator.add_attr("x1", "A1", np.float64)
     creator.add_attr("x2", "A1", np.float64)
     assert set(creator.array_names) == {"A1"}
@@ -329,8 +329,8 @@ def test_rename_array_with_attrs():
 def test_rename_array_name_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
-    creator.add_array("B1", ["row"])
+    creator.add_array_creator("A1", ["row"])
+    creator.add_array_creator("B1", ["row"])
     with pytest.raises(ValueError):
         creator.rename_array("A1", "B1")
 
@@ -338,7 +338,7 @@ def test_rename_array_name_exists_error():
 def test_rename_attr():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     creator.add_attr("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
     creator.rename_attr("x1", "y1")
@@ -350,7 +350,7 @@ def test_rename_attr():
 def test_rename_attr_with_set_attr_properties():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     creator.add_attr("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
     creator.set_attr_properties("x1", name="y1")
@@ -362,7 +362,7 @@ def test_rename_attr_with_set_attr_properties():
 def test_rename_attr_name_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     creator.add_attr("x1", "A1", np.float64)
     creator.add_attr("y1", "A1", np.float64)
     with pytest.raises(ValueError):
@@ -372,7 +372,7 @@ def test_rename_attr_name_exists_error():
 def test_rename_attr_dim_name_in_array_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("y1", (0, 4), np.int32)
-    creator.add_array("A1", ["y1"])
+    creator.add_array_creator("A1", ["y1"])
     creator.add_attr("x1", "A1", np.float64)
     with pytest.raises(ValueError):
         creator.rename_attr("x1", "y1")
@@ -397,7 +397,7 @@ def test_rename_dim_dataspace_axis():
 def test_rename_dim_used():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     assert set(creator.dim_names) == {"row"}
     creator.rename_dim("row", "unit")
     assert set(creator.dim_names) == {"unit"}
@@ -409,7 +409,7 @@ def test_rename_dim_used():
 def test_array_no_dims_error():
     creator = DataspaceCreator()
     with pytest.raises(ValueError):
-        creator.add_array("A1", [])
+        creator.add_array_creator("A1", [])
 
 
 def test_rename_dim_name_exists_in_dataspace_error():
@@ -431,7 +431,7 @@ def test_rename_dim_no_merge_error():
 def test_rename_dim_attr_name__in_array_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("y1", (0, 4), np.int32)
-    creator.add_array("A1", ["y1"])
+    creator.add_array_creator("A1", ["y1"])
     creator.add_attr("x1", "A1", np.float64)
     with pytest.raises(ValueError):
         creator.rename_dim("y1", "x1")
@@ -440,7 +440,7 @@ def test_rename_dim_attr_name__in_array_exists_error():
 def test_set_attr_property():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("A1", ["row"])
+    creator.add_array_creator("A1", ["row"])
     creator.add_attr("x1", "A1", np.float64)
     creator.set_attr_properties("x1", fill=-1)
     group_schema = creator.to_schema()
@@ -475,7 +475,7 @@ def test_set_dim_name():
 def test_set_dim_dtype_with_array_check():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
-    creator.add_array("array1", ("row",))
+    creator.add_array_creator("array1", ("row",))
     creator.set_dim_properties("row", dtype=np.uint32)
     dtype = creator.get_dim_property("row", "dtype")
     assert dtype == np.dtype(np.uint32)
@@ -498,7 +498,7 @@ def test_dataspace_creator_name():
 def test_to_schema_bad_array():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, -1], np.int64)
-    creator.add_array("A1", ("row",))
+    creator.add_array_creator("A1", ("row",))
     creator.add_attr("x1", "A1", dtype=np.float64)
     with pytest.raises(RuntimeError):
         creator.to_schema()

--- a/tests/creator/test_dataspace_creator.py
+++ b/tests/creator/test_dataspace_creator.py
@@ -30,11 +30,11 @@ class TestDataspaceCreatorExample1:
         creator.set_array_properties("A1", tiles=(2,))
         creator.set_array_properties("A2", tiles=(2, 4))
         creator.set_array_properties("A3", tiles=[8])
-        creator.add_attr("pressure.data", "A1", np.float64)
-        creator.add_attr("b", "A1", np.float64)
-        creator.add_attr("c", "A1", np.uint64)
-        creator.add_attr("d", "A2", np.uint64)
-        creator.add_attr("e", "A3", np.float64)
+        creator.add_attr_creator("pressure.data", "A1", np.float64)
+        creator.add_attr_creator("b", "A1", np.float64)
+        creator.add_attr_creator("c", "A1", np.uint64)
+        creator.add_attr_creator("d", "A2", np.uint64)
+        creator.add_attr_creator("e", "A3", np.float64)
         return creator
 
     def test_repr(self, dataspace_creator):
@@ -180,7 +180,7 @@ def test_array_name_reserved_error():
 def test_add_attr_no_array_error():
     creator = DataspaceCreator()
     with pytest.raises(KeyError):
-        creator.add_attr("attr", "array1", np.float64)
+        creator.add_attr_creator("attr", "array1", np.float64)
 
 
 def test_add_attr_name_exists_error():
@@ -188,9 +188,9 @@ def test_add_attr_name_exists_error():
     creator.add_dim("row", (0, 3), np.int64)
     creator.add_array_creator("array1", ("row",))
     creator.add_array_creator("array2", ("row",))
-    creator.add_attr("attr1", "array1", np.float64)
+    creator.add_attr_creator("attr1", "array1", np.float64)
     with pytest.raises(ValueError):
-        creator.add_attr("attr1", "array2", np.float64)
+        creator.add_attr_creator("attr1", "array2", np.float64)
 
 
 def test_add_attr_dim_name_in_array_exists_error():
@@ -198,7 +198,7 @@ def test_add_attr_dim_name_in_array_exists_error():
     creator.add_dim("row", (0, 3), np.uint64)
     creator.add_array_creator("array1", ("row",))
     with pytest.raises(ValueError):
-        creator.add_attr("row", "array1", np.float64)
+        creator.add_attr_creator("row", "array1", np.float64)
 
 
 def test_add_attr_axis_data_coord_exists_error():
@@ -206,9 +206,9 @@ def test_add_attr_axis_data_coord_exists_error():
     creator.add_dim("row", (0, 3), np.int64)
     creator.add_array_creator("array1", ("row",))
     creator.add_array_creator("array2", ("row",))
-    creator.add_attr("attr1", "array1", np.float64)
+    creator.add_attr_creator("attr1", "array1", np.float64)
     with pytest.raises(ValueError):
-        creator.add_attr("attr1.data", "array2", np.float64)
+        creator.add_attr_creator("attr1.data", "array2", np.float64)
 
 
 def test_add_dim_name_exists_error():
@@ -237,9 +237,9 @@ def test_remove_array_with_attrs():
     creator.add_dim("row", [0, 10], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_array_creator("A2", ["row"])
-    creator.add_attr("x1", "A1", np.float64)
-    creator.add_attr("x2", "A1", np.float64)
-    creator.add_attr("y1", "A2", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
+    creator.add_attr_creator("x2", "A1", np.float64)
+    creator.add_attr_creator("y1", "A2", np.float64)
     creator.remove_array("A2")
     assert set(creator.array_names) == {"A1"}
     assert set(creator.attr_names) == {"x1", "x2"}
@@ -250,9 +250,9 @@ def test_remove_renamed_array():
     creator.add_dim("row", [0, 10], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_array_creator("A2", ["row"])
-    creator.add_attr("x1", "A1", np.float64)
-    creator.add_attr("x2", "A1", np.float64)
-    creator.add_attr("y1", "A2", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
+    creator.add_attr_creator("x2", "A1", np.float64)
+    creator.add_attr_creator("y1", "A2", np.float64)
     creator.rename_array("A2", "B1")
     creator.remove_array("B1")
     assert set(creator.array_names) == {"A1"}
@@ -263,12 +263,12 @@ def test_remove_attr():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
-    creator.add_attr("x1", "A1", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
     creator.remove_attr("x1")
     assert set(creator.attr_names) == set()
     creator.add_array_creator("A2", ["row"])
-    creator.add_attr("x1", "A2", np.float64)
+    creator.add_attr_creator("x1", "A2", np.float64)
     assert set(creator.attr_names) == {"x1"}
 
 
@@ -319,8 +319,8 @@ def test_rename_array_with_attrs():
     creator.add_dim("row", [0, 3], np.int32)
     creator.add_dim("col", [0, 3], np.int32)
     creator.add_array_creator("A1", ["row", "col"], sparse=True, tiles=[2, 2])
-    creator.add_attr("x1", "A1", np.float64)
-    creator.add_attr("x2", "A1", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
+    creator.add_attr_creator("x2", "A1", np.float64)
     assert set(creator.array_names) == {"A1"}
     creator.rename_array("A1", "B1")
     assert set(creator.array_names) == {"B1"}
@@ -339,7 +339,7 @@ def test_rename_attr():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
-    creator.add_attr("x1", "A1", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
     creator.rename_attr("x1", "y1")
     assert set(creator.attr_names) == {"y1"}
@@ -351,7 +351,7 @@ def test_rename_attr_with_set_attr_properties():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
-    creator.add_attr("x1", "A1", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
     creator.set_attr_properties("x1", name="y1")
     assert set(creator.attr_names) == {"y1"}
@@ -363,8 +363,8 @@ def test_rename_attr_name_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
-    creator.add_attr("x1", "A1", np.float64)
-    creator.add_attr("y1", "A1", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
+    creator.add_attr_creator("y1", "A1", np.float64)
     with pytest.raises(ValueError):
         creator.rename_attr("x1", "y1")
 
@@ -373,7 +373,7 @@ def test_rename_attr_dim_name_in_array_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("y1", (0, 4), np.int32)
     creator.add_array_creator("A1", ["y1"])
-    creator.add_attr("x1", "A1", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
     with pytest.raises(ValueError):
         creator.rename_attr("x1", "y1")
 
@@ -401,7 +401,7 @@ def test_rename_dim_used():
     assert set(creator.dim_names) == {"row"}
     creator.rename_dim("row", "unit")
     assert set(creator.dim_names) == {"unit"}
-    creator.add_attr("x1", "A1", np.int32)
+    creator.add_attr_creator("x1", "A1", np.int32)
     group_schema = creator.to_schema()
     assert group_schema["A1"].domain.has_dim("unit")
 
@@ -432,7 +432,7 @@ def test_rename_dim_attr_name__in_array_exists_error():
     creator = DataspaceCreator()
     creator.add_dim("y1", (0, 4), np.int32)
     creator.add_array_creator("A1", ["y1"])
-    creator.add_attr("x1", "A1", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
     with pytest.raises(ValueError):
         creator.rename_dim("y1", "x1")
 
@@ -441,7 +441,7 @@ def test_set_attr_property():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
-    creator.add_attr("x1", "A1", np.float64)
+    creator.add_attr_creator("x1", "A1", np.float64)
     creator.set_attr_properties("x1", fill=-1)
     group_schema = creator.to_schema()
     attr_schema = group_schema["A1"].attr(0)
@@ -499,6 +499,6 @@ def test_to_schema_bad_array():
     creator = DataspaceCreator()
     creator.add_dim("row", [0, -1], np.int64)
     creator.add_array_creator("A1", ("row",))
-    creator.add_attr("x1", "A1", dtype=np.float64)
+    creator.add_attr_creator("x1", "A1", dtype=np.float64)
     with pytest.raises(RuntimeError):
         creator.to_schema()

--- a/tests/creator/test_dataspace_creator.py
+++ b/tests/creator/test_dataspace_creator.py
@@ -12,8 +12,8 @@ class TestDataspaceCreatorExample1:
     @pytest.fixture
     def dataspace_creator(self):
         creator = DataspaceCreator()
-        creator.add_dim("pressure.index", (0, 3), np.uint64)
-        creator.add_dim("temperature", (1, 8), np.uint64)
+        creator.add_shared_dim("pressure.index", (0, 3), np.uint64)
+        creator.add_shared_dim("temperature", (1, 8), np.uint64)
         creator.add_array_creator("A1", ("pressure.index",))
         filters = tiledb.FilterList(
             [
@@ -164,7 +164,7 @@ def test_create_array_no_array_error():
 
 def test_array_name_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", (0, 3), np.int64)
+    creator.add_shared_dim("row", (0, 3), np.int64)
     creator.add_array_creator("array1", ("row",))
     with pytest.raises(ValueError):
         creator.add_array_creator("array1", ("row",))
@@ -172,7 +172,7 @@ def test_array_name_exists_error():
 
 def test_array_name_reserved_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", (0, 3), np.int64)
+    creator.add_shared_dim("row", (0, 3), np.int64)
     with pytest.raises(ValueError):
         creator.add_array_creator(METADATA_ARRAY_NAME, ("row",))
 
@@ -185,7 +185,7 @@ def test_add_attr_no_array_error():
 
 def test_add_attr_name_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", (0, 3), np.int64)
+    creator.add_shared_dim("row", (0, 3), np.int64)
     creator.add_array_creator("array1", ("row",))
     creator.add_array_creator("array2", ("row",))
     creator.add_attr_creator("attr1", "array1", np.float64)
@@ -195,7 +195,7 @@ def test_add_attr_name_exists_error():
 
 def test_add_attr_dim_name_in_array_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", (0, 3), np.uint64)
+    creator.add_shared_dim("row", (0, 3), np.uint64)
     creator.add_array_creator("array1", ("row",))
     with pytest.raises(ValueError):
         creator.add_attr_creator("row", "array1", np.float64)
@@ -203,7 +203,7 @@ def test_add_attr_dim_name_in_array_exists_error():
 
 def test_add_attr_axis_data_coord_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", (0, 3), np.int64)
+    creator.add_shared_dim("row", (0, 3), np.int64)
     creator.add_array_creator("array1", ("row",))
     creator.add_array_creator("array2", ("row",))
     creator.add_attr_creator("attr1", "array1", np.float64)
@@ -213,9 +213,9 @@ def test_add_attr_axis_data_coord_exists_error():
 
 def test_add_dim_name_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", (1, 4), np.uint64)
+    creator.add_shared_dim("row", (1, 4), np.uint64)
     with pytest.raises(ValueError):
-        creator.add_dim("row", (0, 3), np.int64)
+        creator.add_shared_dim("row", (0, 3), np.int64)
 
 
 def test_get_property_attr_key_error():
@@ -226,7 +226,7 @@ def test_get_property_attr_key_error():
 
 def test_remove_empty_array():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 10], np.int64)
+    creator.add_shared_dim("row", [0, 10], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.remove_array("A1")
     assert set(creator.array_names) == set()
@@ -234,7 +234,7 @@ def test_remove_empty_array():
 
 def test_remove_array_with_attrs():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 10], np.int64)
+    creator.add_shared_dim("row", [0, 10], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_array_creator("A2", ["row"])
     creator.add_attr_creator("x1", "A1", np.float64)
@@ -247,7 +247,7 @@ def test_remove_array_with_attrs():
 
 def test_remove_renamed_array():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 10], np.int64)
+    creator.add_shared_dim("row", [0, 10], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_array_creator("A2", ["row"])
     creator.add_attr_creator("x1", "A1", np.float64)
@@ -261,7 +261,7 @@ def test_remove_renamed_array():
 
 def test_remove_attr():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_attr_creator("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
@@ -274,7 +274,7 @@ def test_remove_attr():
 
 def test_remove_attr_no_attr_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     with pytest.raises(KeyError):
         creator.remove_attr("x1")
@@ -282,7 +282,7 @@ def test_remove_attr_no_attr_error():
 
 def test_remove_dim():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int32)
+    creator.add_shared_dim("row", [0, 7], np.int32)
     assert set(creator.dim_names) == set(["row"])
     creator.remove_dim("row")
     assert set(creator.dim_names) == set()
@@ -290,7 +290,7 @@ def test_remove_dim():
 
 def test_remove_dim_axis_data():
     creator = DataspaceCreator()
-    creator.add_dim("row.data", [0.0, 100.0], np.float64)
+    creator.add_shared_dim("row.data", [0.0, 100.0], np.float64)
     assert set(creator.dim_names) == {"row.data"}
     creator.remove_dim("row.data")
     assert set(creator.dim_names) == set()
@@ -298,7 +298,7 @@ def test_remove_dim_axis_data():
 
 def test_remove_dim_in_use_error():
     creator = DataspaceCreator()
-    creator.add_dim("row.data", [0.0, 100.0], np.float64)
+    creator.add_shared_dim("row.data", [0.0, 100.0], np.float64)
     creator.add_array_creator("A1", ["row.data"], sparse=True)
     creator.add_array_creator("A2", ["row.data"], sparse=True)
     with pytest.raises(ValueError):
@@ -307,7 +307,7 @@ def test_remove_dim_in_use_error():
 
 def test_rename_array():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     assert set(creator.array_names) == {"A1"}
     creator.rename_array("A1", "B1")
@@ -316,8 +316,8 @@ def test_rename_array():
 
 def test_rename_array_with_attrs():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 3], np.int32)
-    creator.add_dim("col", [0, 3], np.int32)
+    creator.add_shared_dim("row", [0, 3], np.int32)
+    creator.add_shared_dim("col", [0, 3], np.int32)
     creator.add_array_creator("A1", ["row", "col"], sparse=True, tiles=[2, 2])
     creator.add_attr_creator("x1", "A1", np.float64)
     creator.add_attr_creator("x2", "A1", np.float64)
@@ -328,7 +328,7 @@ def test_rename_array_with_attrs():
 
 def test_rename_array_name_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_array_creator("B1", ["row"])
     with pytest.raises(ValueError):
@@ -337,7 +337,7 @@ def test_rename_array_name_exists_error():
 
 def test_rename_attr():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_attr_creator("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
@@ -349,7 +349,7 @@ def test_rename_attr():
 
 def test_rename_attr_with_set_attr_properties():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_attr_creator("x1", "A1", np.float64)
     assert set(creator.attr_names) == {"x1"}
@@ -361,7 +361,7 @@ def test_rename_attr_with_set_attr_properties():
 
 def test_rename_attr_name_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_attr_creator("x1", "A1", np.float64)
     creator.add_attr_creator("y1", "A1", np.float64)
@@ -371,7 +371,7 @@ def test_rename_attr_name_exists_error():
 
 def test_rename_attr_dim_name_in_array_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("y1", (0, 4), np.int32)
+    creator.add_shared_dim("y1", (0, 4), np.int32)
     creator.add_array_creator("A1", ["y1"])
     creator.add_attr_creator("x1", "A1", np.float64)
     with pytest.raises(ValueError):
@@ -380,7 +380,7 @@ def test_rename_attr_dim_name_in_array_exists_error():
 
 def test_rename_dim_not_used():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 3], np.int32)
+    creator.add_shared_dim("row", [0, 3], np.int32)
     assert set(creator.dim_names) == {"row"}
     creator.rename_dim("row", "col")
     assert set(creator.dim_names) == {"col"}
@@ -388,7 +388,7 @@ def test_rename_dim_not_used():
 
 def test_rename_dim_dataspace_axis():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 3], np.float64)
+    creator.add_shared_dim("row", [0, 3], np.float64)
     assert set(creator.dim_names) == {"row"}
     creator.rename_dim("row", "col")
     assert set(creator.dim_names) == {"col"}
@@ -396,7 +396,7 @@ def test_rename_dim_dataspace_axis():
 
 def test_rename_dim_used():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     assert set(creator.dim_names) == {"row"}
     creator.rename_dim("row", "unit")
@@ -414,23 +414,23 @@ def test_array_no_dims_error():
 
 def test_rename_dim_name_exists_in_dataspace_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 3], np.int32)
-    creator.add_dim("col", [0, 7], np.int32)
+    creator.add_shared_dim("row", [0, 3], np.int32)
+    creator.add_shared_dim("col", [0, 7], np.int32)
     with pytest.raises(NotImplementedError):
         creator.rename_dim("col", "row")
 
 
 def test_rename_dim_no_merge_error():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 3], np.int32)
-    creator.add_dim("col", [0, 3], np.int32)
+    creator.add_shared_dim("row", [0, 3], np.int32)
+    creator.add_shared_dim("col", [0, 3], np.int32)
     with pytest.raises(NotImplementedError):
         creator.rename_dim("col", "row")
 
 
 def test_rename_dim_attr_name__in_array_exists_error():
     creator = DataspaceCreator()
-    creator.add_dim("y1", (0, 4), np.int32)
+    creator.add_shared_dim("y1", (0, 4), np.int32)
     creator.add_array_creator("A1", ["y1"])
     creator.add_attr_creator("x1", "A1", np.float64)
     with pytest.raises(ValueError):
@@ -439,7 +439,7 @@ def test_rename_dim_attr_name__in_array_exists_error():
 
 def test_set_attr_property():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("A1", ["row"])
     creator.add_attr_creator("x1", "A1", np.float64)
     creator.set_attr_properties("x1", fill=-1)
@@ -450,7 +450,7 @@ def test_set_attr_property():
 
 def test_set_dim_dtype():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.set_dim_properties("row", dtype=np.float64)
     dtype = creator.get_dim_property("row", "dtype")
     assert dtype == np.dtype(np.float64)
@@ -458,7 +458,7 @@ def test_set_dim_dtype():
 
 def test_set_dim_domain():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.set_dim_properties("row", domain=(1, 8))
     domain = creator.get_dim_property("row", "domain")
     assert domain == (1, 8)
@@ -466,7 +466,7 @@ def test_set_dim_domain():
 
 def test_set_dim_name():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.set_dim_properties("row", name="column")
     name = tuple(creator.dim_names)[0]
     assert name == "column"
@@ -474,7 +474,7 @@ def test_set_dim_name():
 
 def test_set_dim_dtype_with_array_check():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, 7], np.int64)
+    creator.add_shared_dim("row", [0, 7], np.int64)
     creator.add_array_creator("array1", ("row",))
     creator.set_dim_properties("row", dtype=np.uint32)
     dtype = creator.get_dim_property("row", "dtype")
@@ -497,7 +497,7 @@ def test_dataspace_creator_name():
 
 def test_to_schema_bad_array():
     creator = DataspaceCreator()
-    creator.add_dim("row", [0, -1], np.int64)
+    creator.add_shared_dim("row", [0, -1], np.int64)
     creator.add_array_creator("A1", ("row",))
     creator.add_attr_creator("x1", "A1", dtype=np.float64)
     with pytest.raises(RuntimeError):

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -249,8 +249,9 @@ class TestConvertNetCDFSimpleCoord1(ConvertNetCDFBase):
             collect_attrs=collect_attrs,
             tiles_by_var={"y": (100.0,)},
         )
-        tiles = converter.get_array_property(array_name, "tiles")
-        assert tiles == (100.0,)
+        domain_creator = converter.get_array_creator(array_name).domain_creator
+        tile = domain_creator.dim_creator(0).tile
+        assert tile == 100.0
 
     @pytest.mark.parametrize(
         "collect_attrs, array_name", [(True, "array0"), (False, "y")]
@@ -262,8 +263,9 @@ class TestConvertNetCDFSimpleCoord1(ConvertNetCDFBase):
             collect_attrs=collect_attrs,
             tiles_by_dims={("x",): (100.0,)},
         )
-        tiles = converter.get_array_property(array_name, "tiles")
-        assert tiles == (100.0,)
+        domain_creator = converter.get_array_creator(array_name).domain_creator
+        tile = domain_creator.dim_creator(0).tile
+        assert tile == 100.0
 
     def test_convert_coordinate_domain_not_set_error(self, netcdf_file):
         converter = NetCDF4ConverterEngine.from_file(netcdf_file, coords_to_dims=True)

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -161,7 +161,7 @@ class TestConverterSimpleNetCDF(ConvertNetCDFBase):
         converter = NetCDF4ConverterEngine.from_file(netcdf_file, coords_to_dims=False)
         converter.add_array_converter("A1", ("row",))
         with pytest.raises(NotImplementedError):
-            converter.add_attr("a1", "array0", np.float64)
+            converter.add_attr_creator("a1", "array0", np.float64)
 
     def test_bad_array_name_error(self, netcdf_file):
         converter = NetCDF4ConverterEngine.from_file(netcdf_file, coords_to_dims=False)

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -205,7 +205,8 @@ class TestConvertNetCDFSimpleCoord1(ConvertNetCDFBase):
             coords_to_dims=True,
             collect_attrs=collect_attrs,
         )
-        converter.set_dim_properties("x", domain=(None, None))
+        shared_x = converter.get_shared_dim("x")
+        shared_x.domain = (None, None)
         converter.convert_to_group(uri)
         with tiledb.cf.Group(uri) as group:
             with group.open_array(attr="y") as array:
@@ -225,7 +226,8 @@ class TestConvertNetCDFSimpleCoord1(ConvertNetCDFBase):
             coords_to_dims=True,
             collect_attrs=True,
         )
-        converter.set_dim_properties("x", domain=(None, None))
+        shared_x = converter.get_shared_dim("x")
+        shared_x.domain = (None, None)
         converter.convert_to_array(uri)
         with tiledb.open(uri, attr="y") as array:
             schema = array.schema
@@ -305,8 +307,10 @@ class TestConvertNetCDFMultiCoords(ConvertNetCDFBase):
             coords_to_dims=True,
             collect_attrs=collect_attrs,
         )
-        converter.set_dim_properties("x", domain=(None, None))
-        converter.set_dim_properties("y", domain=(None, None))
+        shared_x = converter.get_shared_dim("x")
+        shared_x.domain = (None, None)
+        shared_y = converter.get_shared_dim("y")
+        shared_y.domain = (None, None)
         converter.convert_to_group(uri)
         with tiledb.cf.Group(uri) as group:
             with group.open_array(attr="z") as array:
@@ -364,7 +368,8 @@ class TestConvertNetCDFCoordWithTiles(ConvertNetCDFBase):
             coords_to_dims=True,
             collect_attrs=collect_attrs,
         )
-        converter.set_dim_properties("index", domain=(1, 4))
+        index_dim = converter.get_shared_dim("index")
+        index_dim.domain = (1, 4)
         converter.convert_to_group(uri)
         with tiledb.cf.Group(uri) as group:
             with group.open_array(attr="y") as array:

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -738,6 +738,6 @@ def test_copy_no_var_error(tmpdir, simple1_netcdf_file, simple2_netcdf_file):
 
 def test_bad_dims_error():
     converter = NetCDF4ConverterEngine()
-    converter.add_dim("row", (0, 10), np.uint32)
+    converter.add_shared_dim("row", (0, 10), np.uint32)
     with pytest.raises(NotImplementedError):
         converter.add_array_converter("array0", ("row",))

--- a/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
+++ b/tests/engines/netcdf4_engine/test_netcdf4_converter_engine.py
@@ -144,13 +144,13 @@ class TestConverterSimpleNetCDF(ConvertNetCDFBase):
 
     def test_rename_array(self, netcdf_file):
         converter = NetCDF4ConverterEngine.from_file(netcdf_file, coords_to_dims=False)
-        converter.rename_array("array0", "A1")
+        converter.get_array_creator("array0").name = "A1"
         names = {array_creator.name for array_creator in converter.array_creators()}
         assert names == set(["A1"])
 
     def test_rename_attr(self, netcdf_file):
         converter = NetCDF4ConverterEngine.from_file(netcdf_file, coords_to_dims=False)
-        converter.rename_attr("x1", "y1")
+        converter.get_array_creator_by_attr("x1").attr_creator("x1").name = "y1"
         attr_names = {
             attr_creator.name for attr_creator in next(converter.array_creators())
         }
@@ -158,7 +158,7 @@ class TestConverterSimpleNetCDF(ConvertNetCDFBase):
 
     def test_rename_dim(self, netcdf_file):
         converter = NetCDF4ConverterEngine.from_file(netcdf_file, coords_to_dims=False)
-        converter.rename_dim("row", "col")
+        converter.get_shared_dim("row").name = "col"
         dim_names = {shared_dim.name for shared_dim in converter.shared_dims()}
         assert dim_names == set(["col"])
 

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -416,36 +416,18 @@ class DataspaceCreator:
         return self._registry.get_array_creator_by_attr(attr_name)
 
     def get_array_property(self, array_name: str, property_name: str) -> Any:
-        """Returns a requested property from an array in the CF dataspace.
-
-        Valid properties are:
-
-            * ``cell_order``: The order in which TileDB stores the cells on disk inside
-              a tile. Valid values are: ``row-major`` (default) or ``C`` for row
-              major; ``col-major`` or ``F`` for column major; or ``Hilbert`` for a
-              Hilbert curve.
-            * ``tile_order``: The order in which TileDB stores the tiles on disk. Valid
-              values are: ``row-major`` or ``C`` (default) for row major; or
-              ``col-major`` or ``F`` for column major.
-            * ``capacity``: The number of cells in a data tile of a sparse fragment.
-            * ``tiles``: An optional ordered list of tile sizes for the dimensions of
-              the array. The length must match the number of dimensions in the array.
-            * ``coords_filters``: Filters for all dimensions that do not otherwise have
-              a specified filter list.
-            * ``dim_filters``: A dict from dimension name to a ``FilterList`` for
-              dimensions in the array. Overrides the values set in ``coords_filters``.
-            * ``offsets_filters``: Filters for the offsets for variable length
-              attributes or dimensions.
-            * ``allows_duplicates``: Specifies if multiple values can be stored at the
-              same coordinate. Only allowed for sparse arrays.
-            * ``sparse``: Specifies if the array is a sparse TileDB array (true) or
-              dense TileDB array (false).
+        """(DEPRECATED) Returns a requested property from an array in the CF dataspace.
 
         Parameters:
             array_name: Name of the array to get the property from.
             property_name: Name of the requested property.
         """
-        # TODO: deprecate this function
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Get array creator properties directly in the array "
+                f"creator, accessible with get_array_creator({array_name}).",
+                DeprecationWarning,
+            )
         array_creator = self._registry.get_array_creator(array_name)
         if property_name == "tiles":
             return tuple(
@@ -459,34 +441,35 @@ class DataspaceCreator:
         return getattr(array_creator, property_name)
 
     def get_attr_property(self, attr_name: str, property_name: str) -> Any:
-        """Returns a requested property for an attribute in the CF dataspace.
-
-        Valid properties are:
-            * ``name``: The name of the attribute.
-            * ``dtype``: Numpy dtype of the attribute.
-            * ``fill``: Fill value for unset cells.
-            * ``var``: Specifies if the attribute is variable length (automatic for
-              bytes/strings).
-            * ``nullable``: Specifies if the attribute is nullable using validity tiles.
-            * ``filters``: Specifies compression filters for the attributes.
+        """(DEPRECATED) Returns a requested property for an attribute in the CF dataspace.
 
         Parameters:
             attr_name: Name of the attribute to get the property from.
             property_name: Name of the requested property.
         """
-        # TODO: deprecate this function
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Get attribute creator properties directly from attribute"
+                f"creator, accessible with get_array_creator_by_attr({attr_name})."
+                f"attr_creator({attr_name}).",
+                DeprecationWarning,
+            )
         attr_creator = self._registry.get_attr_creator(attr_name)
         return getattr(attr_creator, property_name)
 
     def get_dim_property(self, dim_name: str, property_name: str) -> Any:
-        """Returns a requested property for a dimension in the CF dataspace.
+        """(DEPRECATED) Returns a requested property for a dimension in the CF dataspace.
 
-        Valid properties are:
-            * ``name``: The name of the dimension.
-            * ``domain``: The (inclusive) valid range for the dimensions.
-            * ``dtype``: The Numpy data type of the dimension.
+        Parameters:
+            dim_name: Name of the dimension to get the property from.
+            property_name: Name of the requested property.
         """
-        # TODO: deprecate this function
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Get shared dimension properties directly in the shared "
+                f"dimension accessible with get_shared_dim({dim_name}).",
+                DeprecationWarning,
+            )
         dim = self._registry.get_shared_dim(dim_name)
         return getattr(dim, property_name)
 
@@ -512,7 +495,6 @@ class DataspaceCreator:
         Parameters:
             attr_name: Name of the attribute that will be removed.
         """
-        # TODO: deprecate and replace with function directly in array_creator.
         array_creator = self._registry.get_array_creator_by_attr(attr_name=attr_name)
         array_creator.remove_attr_creator(attr_name)
 

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -112,10 +112,7 @@ class DataspaceCreator:
         allows_duplicates: bool = False,
         sparse: bool = False,
     ):
-        """Adds a new array to the CF dataspace.
-
-        The name of each array must be unique. All other properties should satisfy
-        the same requirements as a ``tiledb.ArraySchema``.
+        """(DEPRECATED) Adds a new array to the CF dataspace.
 
         Parameters:
             array_name: Name of the new array to be created.
@@ -324,7 +321,7 @@ class DataspaceCreator:
 
     @property
     def attr_names(self):
-        """A view of the names of attributes in the CF dataspace."""
+        """(DEPRECATED) A view of the names of attributes in the CF dataspace."""
         with warnings.catch_warnings():
             warnings.warn(
                 "Deprecated. Access attribute names directly by iterating over "
@@ -504,7 +501,7 @@ class DataspaceCreator:
         self._registry.deregister_array_creator(array_name)
 
     def remove_attr(self, attr_name: str):
-        """Removes the specified attribute from the CF dataspace.
+        """(DEPRECATED) Removes the specified attribute from the CF dataspace.
 
         Parameters:
             attr_name: Name of the attribute that will be removed.
@@ -525,10 +522,7 @@ class DataspaceCreator:
         array_creator.remove_attr_creator(attr_name)
 
     def remove_dim(self, dim_name: str):
-        """Removes the specified dimension from the CF dataspace.
-
-        This can only be used to remove dimensions that are not currently being used in
-        an array.
+        """(DEPRECATED) Removes the specified dimension from the CF dataspace.
 
         Parameters:
             dim_name: Name of the dimension to be removed.
@@ -551,7 +545,7 @@ class DataspaceCreator:
         self._registry.deregister_shared_dim(dim_name)
 
     def rename_array(self, original_name: str, new_name: str):
-        """Renames an array in the CF dataspace.
+        """(DEPRECATED) Renames an array in the CF dataspace.
 
         Parameters:
             original_name: Current name of the array to be renamed.
@@ -566,7 +560,7 @@ class DataspaceCreator:
         self._registry.get_array_creator(original_name).name = new_name
 
     def rename_attr(self, original_name: str, new_name: str):
-        """Renames an attribute in the CF dataspace.
+        """(DEPRECATED) Renames an attribute in the CF dataspace.
 
         Parameters:
             original_name: Current name of the attribute to be renamed.
@@ -598,7 +592,7 @@ class DataspaceCreator:
         self._registry.get_shared_dim(original_name).name = new_name
 
     def set_array_properties(self, array_name: str, **properties):
-        """Sets properties for an array in the CF dataspace.
+        """(DEPRECATED) Sets properties for an array in the CF dataspace.
 
         Parameters:
             array_name: Name of the array to set properties for.
@@ -628,7 +622,7 @@ class DataspaceCreator:
             setattr(array_creator, property_name, value)
 
     def set_attr_properties(self, attr_name: str, **properties):
-        """Sets properties for an attribute in the CF dataspace.
+        """(DEPRECATED) Sets properties for an attribute in the CF dataspace.
 
         Parameters:
             attr_name: Name of the attribute to set properties for.
@@ -646,7 +640,7 @@ class DataspaceCreator:
             setattr(attr_creator, property_name, value)
 
     def set_dim_properties(self, dim_name: str, **properties):
-        """Sets properties for a shared dimension in the CF dataspace.
+        """(DEPRECATED) Sets properties for a shared dimension in the CF dataspace.
 
         Parameters:
             dim_name: Name of the dimension to set properties for.

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -280,6 +280,21 @@ class DataspaceCreator:
         array_creator.add_attr_creator(attr_name, dtype, fill, var, nullable, filters)
 
     def add_dim(self, dim_name: str, domain: Tuple[Any, Any], dtype: np.dtype):
+        """(DEPRECATED) Adds a new dimension to the CF dataspace.
+
+        Parameters:
+            dim_name: Name of the new dimension to be created.
+            domain: The (inclusive) interval on which the dimension is valid.
+            dtype: The numpy dtype of the values and domain of the dimension.
+        """
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Use add_shared_dim instead.",
+                DeprecationWarning,
+            )
+        SharedDim(self._registry, dim_name, domain, dtype)
+
+    def add_shared_dim(self, dim_name: str, domain: Tuple[Any, Any], dtype: np.dtype):
         """Adds a new dimension to the CF dataspace.
 
         Each dimension name must be unique. Adding a dimension where the name, domain,

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -458,7 +458,8 @@ class DataspaceCreator:
         return getattr(attr_creator, property_name)
 
     def get_dim_property(self, dim_name: str, property_name: str) -> Any:
-        """(DEPRECATED) Returns a requested property for a dimension in the CF dataspace.
+        """(DEPRECATED) Returns a requested property for a dimension in the CF
+        dataspace.
 
         Parameters:
             dim_name: Name of the dimension to get the property from.
@@ -482,6 +483,19 @@ class DataspaceCreator:
         return self._registry.get_shared_dim(dim_name)
 
     def remove_array(self, array_name: str):
+        """(DEPRECATED). Removes the specified array and all its attributes from the CF
+        dataspace.
+
+        Parameters:
+            array_name: Name of the array that will be removed.
+        """
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Use remove_array_creator instead.", DeprecationWarning
+            )
+        self.remove_array_creator(array_name)
+
+    def remove_array_creator(self, array_name: str):
         """Removes the specified array and all its attributes from the CF dataspace.
 
         Parameters:
@@ -490,6 +504,18 @@ class DataspaceCreator:
         self._registry.deregister_array_creator(array_name)
 
     def remove_attr(self, attr_name: str):
+        """Removes the specified attribute from the CF dataspace.
+
+        Parameters:
+            attr_name: Name of the attribute that will be removed.
+        """
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Use remove_attr_creator instead.", DeprecationWarning
+            )
+        self.remove_attr_creator(attr_name)
+
+    def remove_attr_creator(self, attr_name: str):
         """Removes the specified attribute from the CF dataspace.
 
         Parameters:
@@ -507,6 +533,21 @@ class DataspaceCreator:
         Parameters:
             dim_name: Name of the dimension to be removed.
         """
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Use remove_shared_dim instead.", DeprecationWarning
+            )
+        self.remove_shared_dim(dim_name)
+
+    def remove_shared_dim(self, dim_name: str):
+        """Removes the specified dimension from the CF dataspace.
+
+        This can only be used to remove dimensions that are not currently being used in
+        an array.
+
+        Parameters:
+            dim_name: Name of the dimension to be removed.
+        """
         self._registry.deregister_shared_dim(dim_name)
 
     def rename_array(self, original_name: str, new_name: str):
@@ -516,7 +557,12 @@ class DataspaceCreator:
             original_name: Current name of the array to be renamed.
             new_name: New name the array will be renamed to.
         """
-        # TODO: deprecate and replace with direct call to array name
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Set array creator properties directly in the array "
+                f"creator, accessible with get_array_creator({original_name}).",
+                DeprecationWarning,
+            )
         self._registry.get_array_creator(original_name).name = new_name
 
     def rename_attr(self, original_name: str, new_name: str):
@@ -526,18 +572,29 @@ class DataspaceCreator:
             original_name: Current name of the attribute to be renamed.
             new_name: New name the attribute will be renamed to.
         """
-        # TODO: deprecate and replace with direct call to attribute name
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Set attribute creator properties directly from attribute"
+                f"creator, accessible with get_array_creator_by_attr({original_name})."
+                f"attr_creator({original_name}).",
+                DeprecationWarning,
+            )
         attr_creator = self._registry.get_attr_creator(original_name)
         attr_creator.name = new_name
 
     def rename_dim(self, original_name: str, new_name: str):
-        """Renames a dimension in the CF dataspace.
+        """(DEPRECATED) Renames a dimension in the CF dataspace.
 
         Parameters:
             original_name: Current name of the dimension to be renamed.
             new_name: New name the dimension will be renamed to.
         """
-        # TODO: deprecate and replace with direct call to dimension name
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Set shared dimension properties directly in the shared "
+                f"dimension accessible with get_shared_dim({original_name}).",
+                DeprecationWarning,
+            )
         self._registry.get_shared_dim(original_name).name = new_name
 
     def set_array_properties(self, array_name: str, **properties):
@@ -584,7 +641,6 @@ class DataspaceCreator:
                 f"attr_creator({attr_name}).",
                 DeprecationWarning,
             )
-
         attr_creator = self._registry.get_attr_creator(attr_name)
         for property_name, value in properties.items():
             setattr(attr_creator, property_name, value)

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -390,7 +390,7 @@ class DataspaceCreator:
         """(DEPRECATED) A view of the names of dimensions in the CF dataspace."""
         with warnings.catch_warnings():
             warnings.warn(
-                "Deprecated. Access dimension names directly by iterator over "
+                "Deprecated. Access dimension names directly by iterating over "
                 "shared dimensions.",
                 DeprecationWarning,
             )

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -313,14 +313,24 @@ class DataspaceCreator:
 
     @property
     def array_names(self):
-        """A view of the names of arrays in the CF dataspace."""
-        # TODO: deprecate this function
+        """(DEPREACTED) A view of the names of arrays in the CF dataspace."""
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Access array names directly by iterating over "
+                "array creators.",
+                DeprecationWarning,
+            )
         return self._registry._array_creators.keys()
 
     @property
     def attr_names(self):
         """A view of the names of attributes in the CF dataspace."""
-        # TODO: deprecate this function
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Access attribute names directly by iterating over "
+                "attribute creators in array creators.",
+                DeprecationWarning,
+            )
         return self._registry._attr_to_array.keys()
 
     def create_array(
@@ -380,8 +390,13 @@ class DataspaceCreator:
 
     @property
     def dim_names(self):
-        """A view of the names of dimensions in the CF dataspace."""
-        # TODO: deprecate this function
+        """(DEPRECATED) A view of the names of dimensions in the CF dataspace."""
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Access dimension names directly by iterator over "
+                "shared dimensions.",
+                DeprecationWarning,
+            )
         return self._registry._shared_dims.keys()
 
     def get_array_creator(self, array_name: str):

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABCMeta
 from collections import OrderedDict
 from io import StringIO
@@ -98,6 +99,69 @@ class DataspaceCreator:
         return output.getvalue()
 
     def add_array(
+        self,
+        array_name: str,
+        dims: Sequence[str],
+        cell_order: str = "row-major",
+        tile_order: str = "row-major",
+        capacity: int = 0,
+        tiles: Optional[Sequence[int]] = None,
+        coords_filters: Optional[tiledb.FilterList] = None,
+        dim_filters: Optional[Dict[str, tiledb.FilterList]] = None,
+        offsets_filters: Optional[tiledb.FilterList] = None,
+        allows_duplicates: bool = False,
+        sparse: bool = False,
+    ):
+        """Adds a new array to the CF dataspace.
+
+        The name of each array must be unique. All other properties should satisfy
+        the same requirements as a ``tiledb.ArraySchema``.
+
+        Parameters:
+            array_name: Name of the new array to be created.
+            dims: An ordered list of the names of the shared dimensions for the domain
+                of this array.
+            cell_order: The order in which TileDB stores the cells on disk inside a
+                tile. Valid values are: ``row-major`` (default) or ``C`` for row major;
+                ``col-major`` or ``F`` for column major; or ``Hilbert`` for a Hilbert
+                curve.
+            tile_order: The order in which TileDB stores the tiles on disk. Valid values
+                are: ``row-major`` or ``C`` (default) for row major; or ``col-major`` or
+                ``F`` for column major.
+            capacity: The number of cells in a data tile of a sparse fragment.
+            tiles: An optional ordered list of tile sizes for the dimensions of the
+                array. The length must match the number of dimensions in the array.
+            coords_filters: Filters for all dimensions that are not otherwise set by
+                ``dim_filters.``
+            dim_filters: A dict from dimension name to a :class:`tiledb.FilterList`
+                for dimensions in the array. Overrides the values set in
+                ``coords_filters``.
+            offsets_filters: Filters for the offsets for variable length attributes or
+                dimensions.
+            allows_duplicates: Specifies if multiple values can be stored at the same
+                 coordinate. Only allowed for sparse arrays.
+            sparse: Specifies if the array is a sparse TileDB array (true) or dense
+                TileDB array (false).
+        """
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Use add_array_creator instead.", DeprecationWarning
+            )
+        self.add_array_creator(
+            array_name=array_name,
+            dims=dims,
+            cell_order=cell_order,
+            tile_order=tile_order,
+            capacity=capacity,
+            tiles=tiles,
+            coords_filters=coords_filters,
+            dim_filters=dim_filters,
+            offsets_filters=offsets_filters,
+            allows_duplicates=allows_duplicates,
+            sparse=sparse,
+        )
+
+    def add_array_creator(
         self,
         array_name: str,
         dims: Sequence[str],

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -543,34 +543,16 @@ class DataspaceCreator:
     def set_array_properties(self, array_name: str, **properties):
         """Sets properties for an array in the CF dataspace.
 
-        Valid properties are:
-
-            * ``cell_order``: The order in which TileDB stores the cells on disk inside
-              a tile. Valid values are: ``row-major`` (default) or ``C`` for row
-              major; ``col-major`` or ``F`` for column major; or ``Hilbert`` for a
-              Hilbert curve.
-            * ``tile_order``: The order in which TileDB stores the tiles on disk. Valid
-              values are: ``row-major`` or ``C`` (default) for row major; or
-              ``col-major`` or ``F`` for column major.
-            * ``capacity``: The number of cells in a data tile of a sparse fragment.
-            * ``tiles``: An optional ordered list of tile sizes for the dimensions of
-              the array. The length must match the number of dimensions in the array.
-            * ``coords_filters``: Filters for all dimensions that do not otherwise have
-              a specified filter list.
-            * ``dim_filters``: A dict from dimension name to a ``FilterList`` for
-              dimensions in the array. Overrides the values set in ``coords_filters``.
-            * ``offsets_filters``: Filters for the offsets for variable length
-              attributes or dimensions.
-            * ``allows_duplicates``: Specifies if multiple values can be stored at the
-              same coordinate. Only allowed for sparse arrays.
-            * ``sparse``: Specifies if the array is a sparse TileDB array (true) or
-              dense TileDB array (false).
-
         Parameters:
             array_name: Name of the array to set properties for.
             properties: Keyword arguments for array properties.
         """
-        # TODO: deprecate this function
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Set array creator properties directly in the array "
+                f"creator, accessible with get_array_creator({array_name}).",
+                DeprecationWarning,
+            )
         array_creator = self._registry.get_array_creator(array_name)
         if "tiles" in properties:
             tiles = properties.pop("tiles")
@@ -591,20 +573,18 @@ class DataspaceCreator:
     def set_attr_properties(self, attr_name: str, **properties):
         """Sets properties for an attribute in the CF dataspace.
 
-        Valid properties are:
-            * ``name``: The name of the attribute.
-            * ``dtype``: Numpy dtype of the attribute.
-            * ``fill``: Fill value for unset cells.
-            * ``var``: Specifies if the attribute is variable length (automatic for
-              bytes/strings).
-            * ``nullable``: Specifies if the attribute is nullable using validity tiles.
-            * ``filters``: Specifies compression filters for the attributes.
-
         Parameters:
             attr_name: Name of the attribute to set properties for.
             properties: Keyword arguments for attribute properties.
         """
-        # TODO: deprecate this function
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Set attribute creator properties directly from attribute"
+                f"creator, accessible with get_array_creator_by_attr({attr_name})."
+                f"attr_creator({attr_name}).",
+                DeprecationWarning,
+            )
+
         attr_creator = self._registry.get_attr_creator(attr_name)
         for property_name, value in properties.items():
             setattr(attr_creator, property_name, value)
@@ -612,16 +592,16 @@ class DataspaceCreator:
     def set_dim_properties(self, dim_name: str, **properties):
         """Sets properties for a shared dimension in the CF dataspace.
 
-        Valid properties are:
-            * ``name``: The name of the dimension.
-            * ``domain``: The (inclusive) inverval on which the dimension is valid.
-            * ``dtype``: The data type of the dimension.
-
         Parameters:
             dim_name: Name of the dimension to set properties for.
             properties: Keyword arguments for dimension properties.
         """
-        # TODO: deprecate this function
+        with warnings.catch_warnings():
+            warnings.warn(
+                f"Deprecated. Set shared dimension properties directly in the shared "
+                f"dimension accessible with get_shared_dim({dim_name}).",
+                DeprecationWarning,
+            )
         dim = self._registry.get_shared_dim(dim_name)
         for property_name, value in properties.items():
             setattr(dim, property_name, value)

--- a/tiledb/cf/creator.py
+++ b/tiledb/cf/creator.py
@@ -231,6 +231,36 @@ class DataspaceCreator:
         nullable: bool = False,
         filters: Optional[tiledb.FilterList] = None,
     ):
+        """(DEPRECATED) Adds a new attribute to an array in the CF dataspace.
+
+        Parameters:
+            attr_name: Name of the new attribute that will be added.
+            array_name: Name of the array the attribute will be added to.
+            dtype: Numpy dtype of the new attribute.
+            fill: Fill value for unset cells.
+            var: Specifies if the attribute is variable length (automatic for
+                byte/strings).
+            nullable: Specifies if the attribute is nullable using validity tiles.
+            filters: Specifies compression filters for the attribute.
+        """
+        with warnings.catch_warnings():
+            warnings.warn(
+                "Deprecated. Use add_attr_creator instead.", DeprecationWarning
+            )
+        self.add_attr_creator(
+            attr_name, array_name, dtype, fill, var, nullable, filters
+        )
+
+    def add_attr_creator(
+        self,
+        attr_name: str,
+        array_name: str,
+        dtype: np.dtype,
+        fill: Optional[Union[int, float, str]] = None,
+        var: bool = False,
+        nullable: bool = False,
+        filters: Optional[tiledb.FilterList] = None,
+    ):
         """Adds a new attribute to an array in the CF dataspace.
 
         The 'dataspace name' (name after dropping the suffix ``.data`` or ``.index``)
@@ -246,7 +276,6 @@ class DataspaceCreator:
             nullable: Specifies if the attribute is nullable using validity tiles.
             filters: Specifies compression filters for the attribute.
         """
-        # TODO deprecate in favor of get_array_creator[name].add_attr_creator
         array_creator = self._registry.get_array_creator(array_name)
         array_creator.add_attr_creator(attr_name, dtype, fill, var, nullable, filters)
 

--- a/tiledb/cf/engines/netcdf4_engine.py
+++ b/tiledb/cf/engines/netcdf4_engine.py
@@ -1245,7 +1245,6 @@ class NetCDF4ConverterEngine(DataspaceCreator):
                 dataspace.
             ValueError: Cannot create a new attribute with the provided ``attr_name``.
         """
-        # TODO: deprecate this function
         try:
             array_creator = self._registry.get_array_creator(array_name)
         except KeyError as err:  # pragma: no cover

--- a/tiledb/cf/engines/netcdf4_engine.py
+++ b/tiledb/cf/engines/netcdf4_engine.py
@@ -922,13 +922,17 @@ class NetCDF4ConverterEngine(DataspaceCreator):
                         f"Cannot name array of scalar values `{scalar_array_name}`. An"
                         f" array with that name already exists."
                     )
-                if scalar_array_name not in converter.array_names:
+                if scalar_array_name not in {
+                    array_creator.name for array_creator in converter.array_creators()
+                }:
                     converter.add_scalar_to_dim_converter("__scalars", dim_dtype)
                     converter.add_array_converter(scalar_array_name, ("__scalars",))
                 converter.add_var_to_attr_converter(ncvar, scalar_array_name)
             else:
                 for dim in ncvar.get_dims():
-                    if dim.name not in converter.dim_names:
+                    if dim.name not in {
+                        shared_dim.name for shared_dim in converter.shared_dims()
+                    }:
                         converter.add_dim_to_dim_converter(
                             dim,
                             unlimited_dim_size,
@@ -1000,7 +1004,9 @@ class NetCDF4ConverterEngine(DataspaceCreator):
                 converter.add_coord_to_dim_converter(ncvar)
                 coord_names.add(ncvar.name)
             else:
-                if not ncvar.dimensions and "__scalars" not in converter.dim_names:
+                if not ncvar.dimensions and "__scalars" not in {
+                    shared_dim.name for shared_dim in converter.shared_dims()
+                }:
                     converter.add_scalar_to_dim_converter("__scalars", dim_dtype)
                 dim_names = ncvar.dimensions if ncvar.dimensions else ("__scalars",)
                 dims_to_vars[dim_names].append(ncvar.name)
@@ -1020,7 +1026,9 @@ class NetCDF4ConverterEngine(DataspaceCreator):
         # Add index dimensions to converter.
         for ncvar in netcdf_group.variables.values():
             for dim in ncvar.get_dims():
-                if dim.name not in converter.dim_names:
+                if dim.name not in {
+                    shared_dim.name for shared_dim in converter.shared_dims()
+                }:
                     converter.add_dim_to_dim_converter(
                         dim,
                         unlimited_dim_size,


### PR DESCRIPTION
Deprecate old DataspaceCreator API in favor of better naming consistency and direct access to dataspace components when applicable.