### PR TITLE
Fixes copying variable metadata to drop redundant key '_FillValue'

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 ### Bug fixes
 
 * Fixes converting NetCDF fill value to TileDB fill value when they are different.
+* Fixes copying metadata from NetCDF variable to TileDB attribute to drop `_FillValue`.
 
 ### Breaking Behavior
 

--- a/tests/netcdf_engine/test_netcdf4_converter_engine.py
+++ b/tests/netcdf_engine/test_netcdf4_converter_engine.py
@@ -991,6 +991,15 @@ class TestConverterNetCDFVariabelWithFill(ConvertNetCDFBase):
                 expected = np.array([np.nan])
                 np.testing.assert_equal(result, expected)
 
+    def test_fill_value_not_in_metadata(self, netcdf_file, tmpdir):
+        """Test that NetCDF attribute `_FillValue` is not copied to TileDB."""
+        uri = str(tmpdir.mkdir("output").join(self.name))
+        converter = NetCDF4ConverterEngine.from_file(netcdf_file)
+        converter.convert_to_group(uri)
+        with Group(uri) as group:
+            with group.open_array(attr="x") as array:
+                assert "_FillValue" not in array.meta
+
 
 def test_virtual_from_netcdf(group1_netcdf_file, tmpdir):
     uri = str(tmpdir.mkdir("output").join("virtual1"))
@@ -1105,7 +1114,7 @@ def test_nested_groups(tmpdir, group1_netcdf_file):
 
 
 def test_variable_fill(tmpdir):
-    """Test converting a NetCDF variable will the _FillValue NetCDF attribute set."""
+    """Test converting a NetCDF variable with the _FillValue NetCDF attribute set."""
     filepath = str(tmpdir.mkdir("sample_netcdf").join("test_fill.nc"))
     with netCDF4.Dataset(filepath, mode="w") as dataset:
         dataset.createDimension("row", 4)

--- a/tiledb/cf/netcdf_engine/_attr_converters.py
+++ b/tiledb/cf/netcdf_engine/_attr_converters.py
@@ -125,6 +125,8 @@ class NetCDF4VarToAttrConverter(NetCDF4ToAttrConverter):
             ) from err
         attr_meta = AttrMetadata(tiledb_array.meta, self.name)
         for key in variable.ncattrs():
+            if key == "_FillValue":
+                continue
             if self.unpack and key in {"scale_factor", "add_offset"}:
                 continue
             safe_set_metadata(attr_meta, key, variable.getncattr(key))


### PR DESCRIPTION
The fill value is copied directly to the TileDB 'fill' property.