### PR TITLE
Changes xarray backend to save timestamp at time of opening

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,13 +4,18 @@
 
 ### Bug fixes
 
+* Fixes timestamp when reading xarray dataset metadata.
+
 ### Breaking Behavior
+
+* Xarray dataset will use timestamp from when array was opened.
 
 ### New Features
 
 ### Improvements
 
 ### Deprecation
+
 
 ## 0.5.3
 

--- a/tests/xarray_engine/test_plugin_timestamp.py
+++ b/tests/xarray_engine/test_plugin_timestamp.py
@@ -1,0 +1,81 @@
+# Copyright 2021 TileDB Inc.
+# Licensed under the MIT License.
+
+import numpy as np
+import pytest
+
+import tiledb
+
+xr = pytest.importorskip("xarray")
+
+
+class TestOpenDatasetTimestep:
+    """Test reading an empty TileDB array into xarray."""
+
+    @pytest.fixture(scope="class")
+    def tiledb_uri(self, tmpdir_factory):
+        """Creates a TileDB array and returns the URI."""
+        uri = str(tmpdir_factory.mktemp("output").join("empty_array"))
+        tiledb.Array.create(
+            uri,
+            tiledb.ArraySchema(
+                domain=tiledb.Domain(
+                    tiledb.Dim("x", domain=(0, 3), dtype=np.uint64),
+                ),
+                attrs=[tiledb.Attr("z", dtype=np.float64)],
+            ),
+        )
+        with tiledb.open(uri, mode="w", timestamp=1) as array:
+            array[:] = np.zeros((4))
+            array.meta["global"] = 0
+            array.meta["__tiledb_attr.z.variable"] = 0
+        with tiledb.open(uri, mode="w", timestamp=2) as array:
+            array[:] = np.ones((4))
+            array.meta["global"] = 1
+            array.meta["__tiledb_attr.z.variable"] = 1
+        with tiledb.open(uri, mode="w", timestamp=3) as array:
+            array[1] = 2
+            array.meta["global"] = 2
+            array.meta["__tiledb_attr.z.variable"] = 2
+        with tiledb.open(uri, mode="w", timestamp=4) as array:
+            array[2] = 3
+            array.meta["global"] = 3
+            array.meta["__tiledb_attr.z.variable"] = 3
+        return uri
+
+    def test_variable_data_timestamp_int(self, tiledb_uri):
+        result = xr.open_dataset(tiledb_uri, timestamp=2, engine="tiledb")
+        expected = xr.Dataset({"z": xr.DataArray(np.ones((4)), dims=("x",))})
+        xr.testing.assert_equal(result, expected)
+
+    def test_variable_metadata_timestamp_int(self, tiledb_uri):
+        result = xr.open_dataset(tiledb_uri, timestamp=2, engine="tiledb")
+        assert result["z"].attrs["variable"] == 1
+
+    def test_global_metadata_timestamp_int(self, tiledb_uri):
+        result = xr.open_dataset(tiledb_uri, timestamp=2, engine="tiledb")
+        assert result.attrs["global"] == 1
+
+    def test_variable_data_timestamp_tuple(self, tiledb_uri):
+        result = xr.open_dataset(tiledb_uri, timestamp=(2, 3), engine="tiledb")
+        expected = xr.Dataset({"z": xr.DataArray(np.array((1, 2, 1, 1)), dims=("x",))})
+        xr.testing.assert_equal(result, expected)
+
+    def test_variable_metadata_timestamp_tuple(self, tiledb_uri):
+        result = xr.open_dataset(tiledb_uri, timestamp=(2, 3), engine="tiledb")
+        assert result["z"].attrs["variable"] == 2
+
+    def test_global_metadata_timestamp_tuple(self, tiledb_uri):
+        result = xr.open_dataset(tiledb_uri, timestamp=(2, 3), engine="tiledb")
+        assert result.attrs["global"] == 2
+
+    def test_implicit_timestamp(self, tiledb_uri):
+        result = xr.open_dataset(tiledb_uri, engine="tiledb")
+        expected = xr.Dataset({"z": xr.DataArray(np.array((1, 2, 3, 1)), dims=("x",))})
+        with tiledb.open(tiledb_uri, mode="w") as array:
+            array[3] = 4
+            array.meta["global"] = 4
+            array.meta["__tiledb_attr.z.variable"] = 4
+        assert result.attrs["global"] == 3
+        assert result["z"].attrs["variable"] == 3
+        xr.testing.assert_equal(result, expected)

--- a/tiledb/cf/xarray_engine/backend_engine.py
+++ b/tiledb/cf/xarray_engine/backend_engine.py
@@ -327,7 +327,9 @@ class TileDBDataStore(AbstractDataStore):
         metadata returned here metadata for the dataset, but excludes encoding data for
         TileDB and attribute metadata.
         """
-        with tiledb.open(self._uri, key=self._key, mode="r", ctx=self._ctx) as array:
+        with tiledb.open(
+            self._uri, mode="r", timestamp=self._timestamp, key=self._key, ctx=self._ctx
+        ) as array:
             attrs = {
                 key: array.meta[key]
                 for key in array.meta.keys()


### PR DESCRIPTION
This PR updates the TileDB-xarray backend so that it returns the data from the timestamp specified when first opening the dataset when no explicit timestamp is provided. Note the user can still change the data in the xarray dataset before it is loaded by explicitly writing data to a timestamp earlier than when it is opened. To mimic the earlier behavior, a user can explicitly open the TileDB array for a future timestamp.

Fixes:
* Uses saved timestamp when getting TileDB metadata

Changes:
* If no timestamp is provided, use the timestamp at time of opening.