### PR TITLE
Split into fast vs full test suite

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,12 +1,11 @@
 name: CI-Full
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - review_requested
       - ready_for_review
-  workflow_dispatch:
-
 
 jobs:
   precommit_checks:

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,16 +1,43 @@
-name: CI
+name: CI-Full
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    types:
+      - review_requested
+      - ready_for_review
+  workflow_dispatch:
 
 
 jobs:
+  precommit_checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python -m pip install -r requirements_dev.txt
+      - name: Run black
+        run: black --check .
+      - name: Run isort
+        run: isort --check .
+      - name: Run flake8
+        run: flake8 --statistics .
+
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.8', '3.11']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
If this works as expected, "fast" CI runs will test against Ubuntu with Python 3.8 and 3.11. The "full" tests will be run on when the PR is ready for review, a review is requested, or manually triggered.