### PR TITLE
Relax the Dataspace CF convention

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,11 @@
 * Removes Group class.
 * Removes GroupSchema class.
 * Moves `creator` module into the `core` module.
+* Updates Dataspace Convention to 0.3.0.
+    - Replaces group-level metadata array with group metadata.
+    - Removes dataspace names.
+* Removes function `dataspace_name`.
+* Removes constants `INDEX_SUFFIX` and `DATA_SUFFIX`.
 
 ### Deprecation
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@
     - Replaces group-level metadata array with group metadata.
     - Removes dataspace names.
     - Removes requirement attribute are unique.
+    - Add dimension-level metadata.
     - Redefines Simple CF Dataspace.
 * Removes function `dataspace_name`.
 * Removes constants `INDEX_SUFFIX` and `DATA_SUFFIX`.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,8 @@
 * Updates Dataspace Convention to 0.3.0.
     - Replaces group-level metadata array with group metadata.
     - Removes dataspace names.
+    - Removes requirement attribute are unique.
+    - Redefines Simple CF Dataspace.
 * Removes function `dataspace_name`.
 * Removes constants `INDEX_SUFFIX` and `DATA_SUFFIX`.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install tiledb-cf
 
 ### Documentation
 
-Coming soon.
+Documentation is available at: [https://tiledb-inc.github.io/TileDB-CF-Py](https://tiledb-inc.github.io/TileDB-CF-Py/)
 
 ### Example Notebooks
 

--- a/documentation/tiledb-cf-spec.md
+++ b/documentation/tiledb-cf-spec.md
@@ -8,7 +8,119 @@ The current dataspace specification is not stable. Backwards compatibility is no
 
 ## Current TileDB-CF Dataspace Specification
 
-* The current TileDB-CF format version number is **0.2.0**.
+* The current TileDB-CF format version number is **0.3.0**.
+
+### TileDB-CF Dataspace 0.3.0
+
+A TileDB CF dataspace is a TileDB group with arrays, attributes, and dimensions that satisfy the following rules.
+
+#### Terminology
+
+* **Collection of dimensions**: A set of TileDB dimensions with the same name, data type, and domain.
+
+#### CF Dataspace
+
+**Requirements for Dimensions**
+
+1. All dimensions that share a name must belong to the same collection (they must have the same domain and data type).
+
+**Requirements for Metadata**
+
+1. Attribute metadata is stored in the same array the attribute is stored in. The metadata key must use the prefix `__tiledb_attr.{attr_name}.` where `{attr_name}` is the full name of the attribute.
+2. If the metadata key `_FillValue` exists for an attribute; it must have the same value as the fill value for the attribute.
+
+### Simple CF Dataspace
+
+A simple CF dataspace is a direct implementation of the NetCDF data model in TileDB. It follows the same rules as a CF dataspace along with the following requirements:
+
+**Additional Requirements for Dimensions**
+
+1. All dimensions use integer indices and have a domain with lower bound of 0.
+
+**Additional Requirements for Arrays**
+
+2. All arrays in the group are named and have a single attribute.
+
+## Specification Q&A
+
+1. Why have a special specification for the TileDB-CF library?
+
+    The TileDB data model is very general and can be used to support a wide-range of applications. However, there is always a push-and-pull between how general your data model is and enabling specific behavior or interpretations for the data. The purpose of the TileDB-CF specification is to handle the case where we have multiple TileDB arrays defined on the same underlying dimensions. By creating a specificiation we make our assumptions explicit and let users know exactly what they must do to use this tool.
+
+
+2. Is the specification backwards compatible?
+
+    Not yet. This library and data model are still under initial development. When the data model has stabalized we will release a 1.0.0 version.
+
+3. Why is there both a library version and a specification version?
+
+    The TileDB-CF python package will update much more frequently the specification. The specification is more-or-less just a summary of the conventions the TileDB-CF library is using. As such, a change to the specification version will always coincide to a change to the library version, but the library version can update without effecting the specification.
+
+4. What version is my current data?
+
+    The TileDB-CF dataspace specification is fairly minimal. Your data may satisfy multiple versions. Currently, we do not provide support for checking your data satisfies the TileDB-CF dataspace convention, but some such tooling will be implemented before the 1.0.0 release of this specification.
+
+
+## Changelog
+
+### Version 0.3.0
+
+* Terminology
+
+    - Remove notion of a dataspace name.
+
+* CF Dataspace
+
+    - Remove requirement that all attributes and dimension are named (allow anonymous attributes and dimensions).
+    - Remove group metadata array. Group metadata is now directly supported in the TileDB core engine.
+    - Remove the notion of a dataspace name and the associated requirements.
+    - Remove requirement attributes have unique dataspace names for general CF Datspace.
+
+* Simple CF Dataspace
+
+    - Remove requiment all collections of dimension have a unique dataspace name.
+    - Add requirement all arrays are uniquely named and have a single attribute.
+
+### Version 0.2.0
+
+- Major revision. See appendix for full specification.
+
+### Version 0.1.0
+
+- Initial release. See appendix for full specification.
+
+
+## Appendix
+
+### TileDB-CF Dataspace 0.1.0
+
+#### Terminology
+
+* **Index dimension**: A TileDB dimension with an integer data type and domain with `0` as its lower bound.
+* **Data dimension**: Any TileDB dimension that is not an index dimension.
+* **Dataspace name**: The name of an attribute or dimension stripped of an optional suffix of `.index` or `.data`.
+
+#### CF Dataspace
+
+**Requirements for Attributes and Dimensions**
+
+1. All attributes and dimension must be named (there must not be any anonymous attributes or dimensions).
+2. All dimensions that share a name must have the same domain and data type.
+3. All attributes must have a unique dataspace name.
+4. If an attribute and data dimension share the same dataspace name, they must share the same full name and data type.
+
+**Requirements for Metadata**
+
+1. Group metadata is stored in a special metadata array named `__tiledb_group` inside the TileDB group.
+2. Attribute metadata is stored in the array the attribute is in using the prefix `__tiledb_attr.{attr_name}.` for the attribute key where `{attr_name}` is the full name of the attribute.
+3. If the metadata key `_FillValue` exists for an attribute; it must have the same value as the fill value for the attribute.
+
+#### Indexable CF Dataspace
+
+A CF Dataspace is said to be indexable if it satisfies all requirements of a CF Dataspace along with the following condition:
+
+* All data dimensions must have an axis label that maps an index dimension with the same dataspace name as the data dimension to an attribute with the same full name and data type as the data dimension.
+
 
 ### TileDB-CF Dataspace 0.2.0
 
@@ -43,62 +155,3 @@ A simple CF dataspace is a direct implementation of the NetCDF data model in Til
 
 1. All dimensions use integer indices and have a domain with lower bound of 0.
 2. All collections of dimensions must have a unique dataspace name.
-
-
-## Specification Q&A
-
-1. Why have a special specification for the TileDB-CF library?
-
-    The TileDB data model is very general and can be used to support a wide-range of applications. However, there is always a push-and-pull between how general your data model is and enabling specific behavior or interpretations for the data. The purpose of the TileDB-CF specification is to handle the case where we have multiple TileDB arrays defined on the same underlying dimensions. By creating a specificiation we make our assumptions explicit and let users know exactly what they must do to use this tool.
-
-
-2. Is the specification backwards compatible?
-
-    Not yet. This library and data model are still under initial development. When the data model has stabalized we will release a 1.0.0 version.
-
-3. Why is there both a library version and a specification version?
-
-    The TileDB-CF python package will update much more frequently the specification. The specification is more-or-less just a summary of the conventions the TileDB-CF library is using. As such, a change to the specification version will always coincide to a change to the library version, but the library version can update without effecting the specification.
-
-4. What version is my current data?
-
-    The TileDB-CF dataspace specification is fairly minimal. Your data may satisfy multiple versions. Currently, we do not provide support for checking your data satisfies the TileDB-CF dataspace convention, but some such tooling will be implemented before the 1.0.0 release of this specification.
-
-
-## Changelog
-
-### Version 0.1.0
-
-- Initial release. See :ref:`cf-spec-0.1.0`
-
-
-## Appendix
-
-### TileDB-CF Dataspace 0.1.0
-
-#### Terminology
-
-* **Index dimension**: A TileDB dimension with an integer data type and domain with `0` as its lower bound.
-* **Data dimension**: Any TileDB dimension that is not an index dimension.
-* **Dataspace name**: The name of an attribute or dimension stripped of an optional suffix of `.index` or `.data`.
-
-#### CF Dataspace
-
-**Requirements for Attributes and Dimensions**
-
-1. All attributes and dimension must be named (there must not be any anonymous attributes or dimensions).
-2. All dimensions that share a name must have the same domain and data type.
-3. All attributes must have a unique dataspace name.
-4. If an attribute and data dimension share the same dataspace name, they must share the same full name and data type.
-
-**Requirements for Metadata**
-
-1. Group metadata is stored in a special metadata array named `__tiledb_group` inside the TileDB group.
-2. Attribute metadata is stored in the array the attribute is in using the prefix `__tiledb_attr.{attr_name}.` for the attribute key where `{attr_name}` is the full name of the attribute.
-3. If the metadata key `_FillValue` exists for an attribute; it must have the same value as the fill value for the attribute.
-
-#### Indexable CF Dataspace
-
-A CF Dataspace is said to be indexable if it satisfies all requirements of a CF Dataspace along with the following condition:
-
-* All data dimensions must have an axis label that maps an index dimension with the same dataspace name as the data dimension to an attribute with the same full name and data type as the data dimension.

--- a/documentation/tiledb-cf-spec.md
+++ b/documentation/tiledb-cf-spec.md
@@ -26,8 +26,8 @@ A TileDB CF dataspace is a TileDB group with arrays, attributes, and dimensions 
 
 **Requirements for Metadata**
 
-1. Attribute metadata is stored in the same array the attribute is stored in. The metadata key must use the prefix `__tiledb_attr.{attr_name}.` where `{attr_name}` is the full name of the attribute.
-2. Dimension metadata is store in the same array as the dimension. The metadta key must use the prefix `__tiledb_dim.{dim_name}.` where `{dim_name}` is the full name of the dimension.
+1. Attribute metadata is stored in the same array as the attribute. The metadata key must use the prefix `__tiledb_attr.{attr_name}.` where `{attr_name}` is the full name of the attribute.
+2. Dimension metadata is stored in the same array as the dimension. The metadata key must use the prefix `__tiledb_dim.{dim_name}.` where `{dim_name}` is the full name of the dimension.
 
 ### Simple CF Dataspace
 
@@ -41,7 +41,7 @@ A simple CF dataspace is a direct implementation of the NetCDF data model in Til
 
 1. All arrays in the group are named and have a single attribute.
 
-**Additional Requirements for Attributes**
+**Additional Requirements for Metadata**
 
 1. There is only group and attribute level metadata.
 

--- a/documentation/tiledb-cf-spec.md
+++ b/documentation/tiledb-cf-spec.md
@@ -27,7 +27,7 @@ A TileDB CF dataspace is a TileDB group with arrays, attributes, and dimensions 
 **Requirements for Metadata**
 
 1. Attribute metadata is stored in the same array the attribute is stored in. The metadata key must use the prefix `__tiledb_attr.{attr_name}.` where `{attr_name}` is the full name of the attribute.
-2. If the metadata key `_FillValue` exists for an attribute; it must have the same value as the fill value for the attribute.
+2. Dimension metadata is store in the same array as the dimension. The metadta key must use the prefix `__tiledb_dim.{dim_name}.` where `{dim_name}` is the full name of the dimension.
 
 ### Simple CF Dataspace
 
@@ -39,7 +39,11 @@ A simple CF dataspace is a direct implementation of the NetCDF data model in Til
 
 **Additional Requirements for Arrays**
 
-2. All arrays in the group are named and have a single attribute.
+1. All arrays in the group are named and have a single attribute.
+
+**Additional Requirements for Attributes**
+
+1. There is only group and attribute level metadata.
 
 ## Specification Q&A
 
@@ -75,11 +79,14 @@ A simple CF dataspace is a direct implementation of the NetCDF data model in Til
     - Remove group metadata array. Group metadata is now directly supported in the TileDB core engine.
     - Remove the notion of a dataspace name and the associated requirements.
     - Remove requirement attributes have unique dataspace names for general CF Datspace.
+    - Remove requirement of `_FillValue`.
+    - Add dimension-level metadata.
 
 * Simple CF Dataspace
 
     - Remove requiment all collections of dimension have a unique dataspace name.
     - Add requirement all arrays are uniquely named and have a single attribute.
+    - Add restriction that metadata only exists for attributes and groups.
 
 ### Version 0.2.0
 

--- a/tests/core/test_array_creator.py
+++ b/tests/core/test_array_creator.py
@@ -53,6 +53,10 @@ class TestArrayCreatorSparseExample1:
         nattr = array_creator.nattr
         assert nattr == 1
 
+    def test_ndim(self, array_creator):
+        ndim = array_creator.ndim
+        assert ndim == 2
+
 
 class TestArrayCreatorDense1:
     @pytest.fixture
@@ -126,6 +130,8 @@ def test_rename_attr():
     array_creator.attr_creator("enthalp").name = "enthalpy"
     attr_names = tuple(attr_creator.name for attr_creator in array_creator)
     assert attr_names == ("enthalpy",)
+    assert not array_creator.has_attr_creator("enthalp")
+    assert array_creator.has_attr_creator("enthalpy")
 
 
 def test_array_no_dim():

--- a/tests/core/test_dataspace_creator.py
+++ b/tests/core/test_dataspace_creator.py
@@ -7,6 +7,47 @@ from tiledb.cf.core._creator import ArrayCreator, SharedDim
 
 
 class TestDataspaceCreatorExample1:
+    expected_schemas = {
+        "A1": tiledb.ArraySchema(
+            domain=tiledb.Domain(
+                tiledb.Dim(
+                    name="pressure.index", domain=(0, 3), tile=2, dtype=np.uint64
+                )
+            ),
+            attrs=[
+                tiledb.Attr(name="pressure.data", dtype=np.float64),
+                tiledb.Attr(name="b", dtype=np.float64),
+                tiledb.Attr(name="c", dtype=np.uint64),
+            ],
+        ),
+        "A2": tiledb.ArraySchema(
+            domain=tiledb.Domain(
+                tiledb.Dim(
+                    name="pressure.index", domain=(0, 3), tile=2, dtype=np.uint64
+                ),
+                tiledb.Dim(
+                    name="temperature",
+                    domain=(1, 8),
+                    tile=4,
+                    dtype=np.uint64,
+                    filters=tiledb.FilterList(
+                        [
+                            tiledb.ZstdFilter(level=1),
+                        ]
+                    ),
+                ),
+            ),
+            sparse=True,
+            attrs=[tiledb.Attr(name="d", dtype=np.uint64)],
+        ),
+        "A3": tiledb.ArraySchema(
+            domain=tiledb.Domain(
+                tiledb.Dim(name="temperature", domain=(1, 8), tile=8, dtype=np.uint64),
+            ),
+            attrs=[tiledb.Attr(name="e", dtype=np.float64)],
+        ),
+    }
+
     @pytest.fixture
     def dataspace_creator(self):
         creator = DataspaceCreator()
@@ -84,44 +125,38 @@ class TestDataspaceCreatorExample1:
         group_schema = dataspace_creator.to_schema()
         assert isinstance(group_schema, dict)
         assert len(group_schema) == 3
-        assert group_schema["A1"] == tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(
-                    name="pressure.index", domain=(0, 3), tile=2, dtype=np.uint64
-                )
-            ),
-            attrs=[
-                tiledb.Attr(name="pressure.data", dtype=np.float64),
-                tiledb.Attr(name="b", dtype=np.float64),
-                tiledb.Attr(name="c", dtype=np.uint64),
-            ],
-        )
-        assert group_schema["A2"] == tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(
-                    name="pressure.index", domain=(0, 3), tile=2, dtype=np.uint64
-                ),
-                tiledb.Dim(
-                    name="temperature",
-                    domain=(1, 8),
-                    tile=4,
-                    dtype=np.uint64,
-                    filters=tiledb.FilterList(
-                        [
-                            tiledb.ZstdFilter(level=1),
-                        ]
-                    ),
-                ),
-            ),
-            sparse=True,
-            attrs=[tiledb.Attr(name="d", dtype=np.uint64)],
-        )
-        assert group_schema["A3"] == tiledb.ArraySchema(
-            domain=tiledb.Domain(
-                tiledb.Dim(name="temperature", domain=(1, 8), tile=8, dtype=np.uint64),
-            ),
-            attrs=[tiledb.Attr(name="e", dtype=np.float64)],
-        )
+        assert group_schema["A1"] == self.expected_schemas["A1"]
+        assert group_schema["A2"] == self.expected_schemas["A2"]
+        assert group_schema["A3"] == self.expected_schemas["A3"]
+
+    def test_create_group(self, dataspace_creator, tmpdir_factory):
+        uri = str(tmpdir_factory.mktemp("output").join("dataspace_example_1"))
+        dataspace_creator.create_group(uri, append=False)
+        with tiledb.Group(uri, mode="r") as group:
+            assert len(group) == 3
+            for item in group:
+                result_schema = tiledb.ArraySchema.load(item.uri)
+                expected_schema = self.expected_schemas[item.name]
+                assert result_schema == expected_schema
+
+
+def test_create_array(tmpdir):
+    # Generate dataspace creator
+    creator = DataspaceCreator()
+    creator.add_shared_dim("d1", (0, 1_000_000), np.uint32)
+    creator.add_array_creator("A1", ("d1"))
+    creator.get_array_creator("A1").add_attr_creator("a1", np.float64)
+
+    # Create the array
+    array_uri = str(tmpdir.mkdir("output").join("example_create_array"))
+    creator.create_array(array_uri)
+
+    # Load and check schema
+    schema = tiledb.ArraySchema.load(array_uri)
+    assert schema == tiledb.ArraySchema(
+        tiledb.Domain(tiledb.Dim("d1", domain=(0, 1_000_000), dtype=np.uint32)),
+        attrs=[tiledb.Attr("a1", dtype=np.float64)],
+    )
 
 
 def test_repr_empty_dataspace():
@@ -170,6 +205,17 @@ def test_add_dim_name_exists_error():
     creator.add_shared_dim("row", (1, 4), np.uint64)
     with pytest.raises(ValueError):
         creator.add_shared_dim("row", (0, 3), np.int64)
+
+
+def test_get_array_creator_by_attr_not_uniquer():
+    creator = DataspaceCreator()
+    creator.add_shared_dim("row", (1, 4), np.uint32)
+    creator.add_array_creator("A1", ["row"])
+    creator.get_array_creator("A1").add_attr_creator("attr", np.int32)
+    creator.add_array_creator("A2", ["row"])
+    creator.get_array_creator("A2").add_attr_creator("attr", np.int32)
+    with pytest.raises(ValueError):
+        creator.get_array_creator_by_attr("attr")
 
 
 def test_remove_empty_array():

--- a/tests/core/test_dataspace_creator.py
+++ b/tests/core/test_dataspace_creator.py
@@ -152,10 +152,9 @@ def test_add_attr_name_exists_error():
     creator = DataspaceCreator()
     creator.add_shared_dim("row", (0, 3), np.int64)
     creator.add_array_creator("array1", ("row",))
-    creator.add_array_creator("array2", ("row",))
     creator.add_attr_creator("attr1", "array1", np.float64)
     with pytest.raises(ValueError):
-        creator.add_attr_creator("attr1", "array2", np.float64)
+        creator.add_attr_creator("attr1", "array1", np.float64)
 
 
 def test_add_attr_dim_name_in_array_exists_error():

--- a/tests/core/test_dataspace_creator.py
+++ b/tests/core/test_dataspace_creator.py
@@ -166,16 +166,6 @@ def test_add_attr_dim_name_in_array_exists_error():
         creator.add_attr_creator("row", "array1", np.float64)
 
 
-def test_add_attr_axis_data_coord_exists_error():
-    creator = DataspaceCreator()
-    creator.add_shared_dim("row", (0, 3), np.int64)
-    creator.add_array_creator("array1", ("row",))
-    creator.add_array_creator("array2", ("row",))
-    creator.add_attr_creator("attr1", "array1", np.float64)
-    with pytest.raises(ValueError):
-        creator.add_attr_creator("attr1.data", "array2", np.float64)
-
-
 def test_add_dim_name_exists_error():
     creator = DataspaceCreator()
     creator.add_shared_dim("row", (1, 4), np.uint64)
@@ -407,14 +397,6 @@ def test_rename_dim_attr_name_in_array_exists_error():
     creator.add_attr_creator("x1", "A1", np.float64)
     with pytest.raises(ValueError):
         creator.get_shared_dim("y1").name = "x1"
-
-
-def test_dataspace_creator_name():
-    from tiledb.cf import dataspace_name
-
-    assert dataspace_name("name.index") == "name"
-    assert dataspace_name("name.data") == "name"
-    assert dataspace_name("name.other") == "name.other"
 
 
 def test_to_schema_bad_array():

--- a/tiledb/cf/__init__.py
+++ b/tiledb/cf/__init__.py
@@ -12,15 +12,12 @@ simply import using:
 from .cli import cli
 from .core import (
     ATTR_METADATA_FLAG,
-    DATA_SUFFIX,
     DIM_METADATA_FLAG,
-    INDEX_SUFFIX,
     ArrayMetadata,
     AttrMetadata,
     DataspaceCreator,
     DimMetadata,
     create_group,
-    dataspace_name,
     open_group_array,
 )
 from .netcdf_engine import from_netcdf, has_netCDF4

--- a/tiledb/cf/core/__init__.py
+++ b/tiledb/cf/core/__init__.py
@@ -1,6 +1,6 @@
 """Core TileDB-CF functionality."""
 
-from ._creator import DATA_SUFFIX, INDEX_SUFFIX, DataspaceCreator, dataspace_name
+from ._creator import DataspaceCreator
 from ._metadata import (
     ATTR_METADATA_FLAG,
     DIM_METADATA_FLAG,

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -888,6 +888,7 @@ class AttrCreator(metaclass=ABCMeta):
     @name.setter
     def name(self, name: str):
         self._array_registry.check_new_attr_name(name)
+        self._array_registry.update_attr_creator_name(self._name, name)
         self._name = name
 
     def to_tiledb(self, ctx: Optional[tiledb.Ctx] = None) -> tiledb.Attr:

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -14,27 +14,6 @@ import tiledb
 from .._utils import DType
 from .api import create_group
 
-DATA_SUFFIX = ".data"
-INDEX_SUFFIX = ".index"
-
-
-def dataspace_name(full_name: str):
-    """Returns dataspace name for from full dimension or attribute name.
-
-    Parameters:
-        full_name: The full name of the dimension or attribute as it will be written in
-            TileDB.
-
-    Returns:
-        The name of the dimension or attribute as it would be written in the NetCDF data
-        model.
-    """
-    if full_name.endswith(DATA_SUFFIX):
-        return full_name[: -len(DATA_SUFFIX)]
-    if full_name.endswith(INDEX_SUFFIX):
-        return full_name[: -len(INDEX_SUFFIX)]
-    return full_name
-
 
 class DataspaceCreator:
     """Creator for a group of arrays that satify the CF Dataspace Convention.
@@ -334,13 +313,6 @@ class DataspaceRegistry:
     def check_new_attr_name(self, attr_name: str):
         if attr_name in self._attr_to_array:
             raise ValueError(f"An attribute with name '{attr_name}' already exists.")
-        ds_name = dataspace_name(attr_name)
-        ds_names = {ds_name, ds_name + DATA_SUFFIX, ds_name + INDEX_SUFFIX}
-        if not ds_names.isdisjoint(self._attr_to_array.keys()):
-            raise ValueError(
-                f"An attribute named with the dataspace name '{ds_name}' already "
-                f"exists."
-            )
 
     def check_new_dim(self, shared_dim: SharedDim):
         if (

--- a/tiledb/cf/xarray_engine/_deprecated_backend_store.py
+++ b/tiledb/cf/xarray_engine/_deprecated_backend_store.py
@@ -30,11 +30,11 @@ try:
 except ModuleNotFoundError:
     has_tiledb = False
 
-from ..core import DATA_SUFFIX, INDEX_SUFFIX
-
 _ATTR_PREFIX = "__tiledb_attr."
 _DIM_PREFIX = "__tiledb_dim."
 _COORD_SUFFIX = ".data"
+_DATA_SUFFIX = ".data"
+_INDEX_SUFFIX = ".index"
 
 
 class TileDBIndexConverter:
@@ -395,10 +395,10 @@ class TileDBDataStore(AbstractDataStore):
         dims = {indexer.name: indexer.size for indexer in index_converters}
         for attr in schema:
             variable_name = attr.name
-            if variable_name.endswith(DATA_SUFFIX):
-                variable_name = variable_name[: -len(DATA_SUFFIX)]
-            elif variable_name.endswith(INDEX_SUFFIX):
-                variable_name = variable_name[: -len(INDEX_SUFFIX)]
+            if variable_name.endswith(_DATA_SUFFIX):
+                variable_name = variable_name[: -len(_DATA_SUFFIX)]
+            elif variable_name.endswith(_INDEX_SUFFIX):
+                variable_name = variable_name[: -len(_INDEX_SUFFIX)]
             data = LazilyIndexedArray(
                 TileDBDenseArrayWrapper(
                     attr,


### PR DESCRIPTION
* Updates Dataspace Convention to 0.3.0.
  * Replaces group-level metadata array with group metadata.
  * Removes dataspace names.
   * Removes requirement attribute are unique.
   *  Redefines Simple CF Dataspace.
* Removes function `dataspace_name`.
* Removes constants `INDEX_SUFFIX` and `DATA_SUFFIX`.