### PR TITLE
Dataspace creator internal clean-up

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     setuptools >= 40.4
     tiledb >= 0.21.2
     click >= 0.7.0
+    typing-extensions >= 4.0.0
 
 [options.extras_require]
 netCDF4 = netCDF4

--- a/tests/core/test_array_creator.py
+++ b/tests/core/test_array_creator.py
@@ -2,19 +2,18 @@ import numpy as np
 import pytest
 
 import tiledb
-from tiledb.cf.core._creator import ArrayCreator, DataspaceRegistry, SharedDim
+from tiledb.cf.core._creator import ArrayCreator, SharedDim
 
 
 class TestArrayCreatorSparseExample1:
     @pytest.fixture
     def array_creator(self):
-        registry = DataspaceRegistry()
-        SharedDim(registry, "row", (0, 63), np.uint32)
-        SharedDim(registry, "col", (0, 31), np.uint32)
         creator = ArrayCreator(
-            registry,
-            "array",
-            ("row", "col"),
+            dim_order=("row", "col"),
+            shared_dims=(
+                SharedDim(None, "row", (0, 63), np.uint32),
+                SharedDim(None, "col", (0, 31), np.uint32),
+            ),
             sparse=True,
             offsets_filters=tiledb.FilterList([tiledb.Bzip2Filter()]),
             tiles=(32, 16),
@@ -32,6 +31,7 @@ class TestArrayCreatorSparseExample1:
 
     def test_create(self, tmpdir, array_creator):
         uri = str(tmpdir.mkdir("output").join("sparse_example_1"))
+        print(array_creator)
         array_creator.create(uri)
         assert tiledb.object_type(uri) == "array"
 
@@ -61,9 +61,9 @@ class TestArrayCreatorSparseExample1:
 class TestArrayCreatorDense1:
     @pytest.fixture
     def array_creator(self):
-        registry = DataspaceRegistry()
-        SharedDim(registry, "row", (0, 63), np.uint32)
-        creator = ArrayCreator(registry, "array", "row")
+        creator = ArrayCreator(
+            shared_dims=[SharedDim(None, "row", (0, 63), np.uint32)], dim_order=("row",)
+        )
         attr_filters = tiledb.FilterList([tiledb.ZstdFilter(level=7)])
         creator.add_attr_creator("enthalpy", np.dtype("float64"), filters=attr_filters)
         return creator
@@ -99,9 +99,11 @@ class TestAttrsFitlers:
         """Tests new attribute filter is set to the attrs_filters value if the
         ``filters`` parameter is not specified."""
         attrs_filters = tiledb.FilterList([tiledb.ZstdFilter()])
-        registry = DataspaceRegistry()
-        SharedDim(registry, "row", (0, 63), np.uint32)
-        creator = ArrayCreator(registry, "array", ("row",), attrs_filters=attrs_filters)
+        creator = ArrayCreator(
+            dim_order=("row",),
+            shared_dims=[SharedDim(None, "row", (0, 63), np.uint32)],
+            attrs_filters=attrs_filters,
+        )
         creator.add_attr_creator("x", np.dtype("float64"))
         assert creator.attr_creator("x").filters == attrs_filters
 
@@ -110,19 +112,22 @@ class TestAttrsFitlers:
         ``filters is not ``None``."""
         attrs_filters = tiledb.FilterList([tiledb.ZstdFilter()])
         new_filters = tiledb.FilterList([tiledb.GzipFilter(level=5)])
-        registry = DataspaceRegistry()
-        SharedDim(registry, "row", (0, 63), np.uint32)
-        creator = ArrayCreator(registry, "array", ("row",), attrs_filters=attrs_filters)
+        creator = ArrayCreator(
+            dim_order=("row",),
+            shared_dims=[SharedDim(None, "row", (0, 63), np.uint32)],
+            attrs_filters=attrs_filters,
+        )
         creator.add_attr_creator("x", np.dtype("float64"), filters=new_filters)
         assert creator.attr_creator("x").filters == new_filters
 
 
 def test_rename_attr():
-    registry = DataspaceRegistry()
-    SharedDim(registry, "pressure", (0.0, 1000.0), np.float64)
-    SharedDim(registry, "temperature", (-200.0, 200.0), np.float64)
+    shared_dims = [
+        SharedDim(None, "pressure", (0.0, 1000.0), np.float64),
+        SharedDim(None, "temperature", (-200.0, 200.0), np.float64),
+    ]
     array_creator = ArrayCreator(
-        registry, "array", ("pressure", "temperature"), sparse=True
+        dim_order=("pressure", "temperature"), shared_dims=shared_dims, sparse=True
     )
     array_creator.add_attr_creator("enthalp", np.dtype("float64"))
     attr_names = tuple(attr_creator.name for attr_creator in array_creator)
@@ -135,61 +140,71 @@ def test_rename_attr():
 
 
 def test_array_no_dim():
-    creator = ArrayCreator(DataspaceRegistry(), "array", [])
+    creator = ArrayCreator()
     assert creator.domain_creator.ndim == 0
 
 
 def test_repeating_name_error():
     with pytest.raises(ValueError):
-        registry = DataspaceRegistry()
-        SharedDim(registry, "x", (1, 4), np.int32)
-        ArrayCreator(registry, "array", ["x", "x"])
+        ArrayCreator(
+            dim_order=("x", "x"),
+            shared_dims=[SharedDim(None, "x", (1, 4), np.int32)],
+        )
 
 
 def test_name_exists_error():
-    registry = DataspaceRegistry()
-    SharedDim(registry, "pressure", (0.0, 1000.0), np.float64)
-    SharedDim(registry, "temperature", (-200.0, 200.0), np.float64)
-    creator = ArrayCreator(registry, "array", ("pressure", "temperature"), sparse=True)
+    shared_dims = [
+        SharedDim(None, "pressure", (0.0, 1000.0), np.float64),
+        SharedDim(None, "temperature", (-200.0, 200.0), np.float64),
+    ]
+    creator = ArrayCreator(
+        dim_order=("pressure", "temperature"), shared_dims=shared_dims, sparse=True
+    )
     creator.add_attr_creator("enthalpy", np.float64)
     with pytest.raises(ValueError):
         creator.add_attr_creator("enthalpy", np.float64)
 
 
 def test_dim_name_exists_error():
-    registry = DataspaceRegistry()
-    SharedDim(registry, "pressure", (0.0, 1000.0), np.float64)
-    SharedDim(registry, "temperature", (-200.0, 200.0), np.float64)
-    creator = ArrayCreator(registry, "array", ("pressure", "temperature"), sparse=True)
+    shared_dims = [
+        SharedDim(None, "pressure", (0.0, 1000.0), np.float64),
+        SharedDim(None, "temperature", (-200.0, 200.0), np.float64),
+    ]
+    creator = ArrayCreator(
+        dim_order=("pressure", "temperature"), shared_dims=shared_dims, sparse=True
+    )
     creator.add_attr_creator("enthalpy", np.float64)
     with pytest.raises(ValueError):
         creator.add_attr_creator("pressure", np.float64)
 
 
 def test_bad_tiles_error():
-    registry = DataspaceRegistry()
-    SharedDim(registry, "row", (0, 63), np.uint32)
-    SharedDim(registry, "col", (0, 31), np.uint32)
+    shared_dims = [
+        SharedDim(None, "row", (0, 63), np.uint32),
+        SharedDim(None, "col", (0, 31), np.uint32),
+    ]
     with pytest.raises(ValueError):
-        ArrayCreator(registry, "array", ("row", "col"), tiles=(4,))
+        ArrayCreator(shared_dims=shared_dims, dim_order=("row", "col"), tiles=(4,))
 
 
 def test_to_schema_no_attrs_error():
-    registry = DataspaceRegistry()
-    SharedDim(registry, "row", (0, 63), np.uint32)
-    SharedDim(registry, "col", (0, 31), np.uint32)
-    creator = ArrayCreator(registry, "array", ("row", "col"))
+    shared_dims = [
+        SharedDim(None, "row", (0, 63), np.uint32),
+        SharedDim(None, "col", (0, 31), np.uint32),
+    ]
+    creator = ArrayCreator(shared_dims=shared_dims, dim_order=("row", "col"))
     with pytest.raises(ValueError):
         creator.to_schema()
 
 
 def test_inject_dim_creator_front():
     """Tests injecting a dimension into the front of the domain."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 7), np.uint32)
-    SharedDim(registry, "x0", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x1", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(shared_dims=shared_dims, dim_order=("x1", "x2"))
     creator.domain_creator.inject_dim_creator("x0", 0)
     dim_names = tuple(dim_creator.name for dim_creator in creator.domain_creator)
     assert dim_names == ("x0", "x1", "x2")
@@ -197,11 +212,12 @@ def test_inject_dim_creator_front():
 
 def test_inject_dim_creator_back():
     """Tests injecting a dimension into the back of the domain."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 7), np.uint32)
-    SharedDim(registry, "x3", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x1", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x3", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.inject_dim_creator("x3", -1)
     dim_names = tuple(dim_creator.name for dim_creator in creator.domain_creator)
     assert dim_names == ("x1", "x2", "x3")
@@ -209,11 +225,12 @@ def test_inject_dim_creator_back():
 
 def test_inject_dim_creator_middle():
     """Tests injecting a dimension into the middle of the domain."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x2"))
+    shared_dims = [
+        SharedDim(None, "x0", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x1", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x2"), shared_dims=shared_dims)
     creator.domain_creator.inject_dim_creator("x1", 1)
     dim_names = tuple(dim_creator.name for dim_creator in creator.domain_creator)
     assert dim_names == ("x0", "x1", "x2")
@@ -222,11 +239,12 @@ def test_inject_dim_creator_middle():
 def test_inject_dim_attr_name_conflict_error():
     """Tests error when injecting a dimension with name matching a current attribute
     name."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x1"))
+    shared_dims = [
+        SharedDim(None, "x0", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x1", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x1"), shared_dims=shared_dims)
     creator.add_attr_creator("x2", dtype=np.int32)
     with pytest.raises(ValueError):
         creator.domain_creator.inject_dim_creator("x2", 0)
@@ -235,10 +253,11 @@ def test_inject_dim_attr_name_conflict_error():
 def test_inject_dim_name_conflict_error():
     """Tests error when injecting a dimension with name matching a current dimension
     name."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x1"))
+    shared_dims = [
+        SharedDim(None, "x0", (0, 7), np.uint32),
+        SharedDim(None, "x1", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x1"), shared_dims=shared_dims)
     with pytest.raises(ValueError):
         creator.domain_creator.inject_dim_creator("x1", 0)
 
@@ -246,11 +265,12 @@ def test_inject_dim_name_conflict_error():
 def test_inject_dim_neg_out_of_bound_error():
     """Tests error when injecting a dimension when poviding a negative position that is
     one element out-of-bounds."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x2"), shared_dims=shared_dims)
     with pytest.raises(IndexError):
         creator.domain_creator.inject_dim_creator("x1", -4)
 
@@ -258,22 +278,24 @@ def test_inject_dim_neg_out_of_bound_error():
 def test_inject_dim_pos_out_of_bound_error():
     """Tests error when injecting a dimension when providing a positive position that is
     one more than the size of the domain after creation."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x2"), shared_dims=shared_dims)
     with pytest.raises(IndexError):
         creator.domain_creator.inject_dim_creator("x1", 3)
 
 
 def test_remove_dim_creator_by_positive_int():
     """Tests removing a dimension using a positive dimension index."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x1", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator(0)
     dim_names = tuple(dim_creator.name for dim_creator in creator.domain_creator)
     assert dim_names == ("x1", "x2")
@@ -281,11 +303,12 @@ def test_remove_dim_creator_by_positive_int():
 
 def test_remove_dim_creator_by_negative_int():
     """Tests removing a dimension using a negative dimension index."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x1", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator(-3)
     dim_names = tuple(dim_creator.name for dim_creator in creator.domain_creator)
     assert dim_names == ("x1", "x2")
@@ -293,11 +316,12 @@ def test_remove_dim_creator_by_negative_int():
 
 def test_remove_dim_creator_front():
     """Tests removing the first dimension in the domain."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x1", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator("x0")
     dim_names = tuple(dim_creator.name for dim_creator in creator.domain_creator)
     assert dim_names == ("x1", "x2")
@@ -305,11 +329,12 @@ def test_remove_dim_creator_front():
 
 def test_remove_dim_creator_back():
     """Tests removing the last dimension in the domain."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 7), np.uint32)
-    SharedDim(registry, "x3", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x1", "x2", "x3"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x3", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x1", "x2", "x3"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator("x3")
     dim_names = tuple(dim_creator.name for dim_creator in creator.domain_creator)
     assert dim_names == ("x1", "x2")
@@ -317,11 +342,12 @@ def test_remove_dim_creator_back():
 
 def test_remove_dim_creator_middle():
     """Tests removing a dimension in the middle of the domain."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x1", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator("x1")
     dim_names = tuple(dim_creator.name for dim_creator in creator.domain_creator)
     assert dim_names == ("x0", "x2")
@@ -330,21 +356,23 @@ def test_remove_dim_creator_middle():
 def test_remove_dim_creator_position_index_error():
     """Tests attempting to remove a dimension that does not exist with a dimension
     index."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x1", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     with pytest.raises(IndexError):
         creator.domain_creator.remove_dim_creator(4)
 
 
 def test_remove_dim_creator_name_key_error():
     """Tests attempting to remove a dimension that does not exist by name."""
-    registry = DataspaceRegistry()
-    SharedDim(registry, "x0", (0, 7), np.uint32)
-    SharedDim(registry, "x1", (0, 7), np.uint32)
-    SharedDim(registry, "x2", (0, 4), np.uint32)
-    creator = ArrayCreator(registry, "array", ("x0", "x1", "x2"))
+    shared_dims = [
+        SharedDim(None, "x1", (0, 7), np.uint32),
+        SharedDim(None, "x2", (0, 7), np.uint32),
+        SharedDim(None, "x0", (0, 4), np.uint32),
+    ]
+    creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     with pytest.raises(KeyError):
         creator.domain_creator.remove_dim_creator("x4")

--- a/tests/core/test_array_creator.py
+++ b/tests/core/test_array_creator.py
@@ -11,8 +11,8 @@ class TestArrayCreatorSparseExample1:
         creator = ArrayCreator(
             dim_order=("row", "col"),
             shared_dims=(
-                SharedDim(None, "row", (0, 63), np.uint32),
-                SharedDim(None, "col", (0, 31), np.uint32),
+                SharedDim("row", (0, 63), np.uint32),
+                SharedDim("col", (0, 31), np.uint32),
             ),
             sparse=True,
             offsets_filters=tiledb.FilterList([tiledb.Bzip2Filter()]),
@@ -61,7 +61,7 @@ class TestArrayCreatorDense1:
     @pytest.fixture
     def array_creator(self):
         creator = ArrayCreator(
-            shared_dims=[SharedDim(None, "row", (0, 63), np.uint32)], dim_order=("row",)
+            shared_dims=[SharedDim("row", (0, 63), np.uint32)], dim_order=("row",)
         )
         attr_filters = tiledb.FilterList([tiledb.ZstdFilter(level=7)])
         creator.add_attr_creator("enthalpy", np.dtype("float64"), filters=attr_filters)
@@ -100,7 +100,7 @@ class TestAttrsFitlers:
         attrs_filters = tiledb.FilterList([tiledb.ZstdFilter()])
         creator = ArrayCreator(
             dim_order=("row",),
-            shared_dims=[SharedDim(None, "row", (0, 63), np.uint32)],
+            shared_dims=[SharedDim("row", (0, 63), np.uint32)],
             attrs_filters=attrs_filters,
         )
         creator.add_attr_creator("x", np.dtype("float64"))
@@ -113,7 +113,7 @@ class TestAttrsFitlers:
         new_filters = tiledb.FilterList([tiledb.GzipFilter(level=5)])
         creator = ArrayCreator(
             dim_order=("row",),
-            shared_dims=[SharedDim(None, "row", (0, 63), np.uint32)],
+            shared_dims=[SharedDim("row", (0, 63), np.uint32)],
             attrs_filters=attrs_filters,
         )
         creator.add_attr_creator("x", np.dtype("float64"), filters=new_filters)
@@ -122,8 +122,8 @@ class TestAttrsFitlers:
 
 def test_rename_attr():
     shared_dims = [
-        SharedDim(None, "pressure", (0.0, 1000.0), np.float64),
-        SharedDim(None, "temperature", (-200.0, 200.0), np.float64),
+        SharedDim("pressure", (0.0, 1000.0), np.float64),
+        SharedDim("temperature", (-200.0, 200.0), np.float64),
     ]
     array_creator = ArrayCreator(
         dim_order=("pressure", "temperature"), shared_dims=shared_dims, sparse=True
@@ -147,14 +147,14 @@ def test_repeating_name_error():
     with pytest.raises(ValueError):
         ArrayCreator(
             dim_order=("x", "x"),
-            shared_dims=[SharedDim(None, "x", (1, 4), np.int32)],
+            shared_dims=[SharedDim("x", (1, 4), np.int32)],
         )
 
 
 def test_name_exists_error():
     shared_dims = [
-        SharedDim(None, "pressure", (0.0, 1000.0), np.float64),
-        SharedDim(None, "temperature", (-200.0, 200.0), np.float64),
+        SharedDim("pressure", (0.0, 1000.0), np.float64),
+        SharedDim("temperature", (-200.0, 200.0), np.float64),
     ]
     creator = ArrayCreator(
         dim_order=("pressure", "temperature"), shared_dims=shared_dims, sparse=True
@@ -166,8 +166,8 @@ def test_name_exists_error():
 
 def test_dim_name_exists_error():
     shared_dims = [
-        SharedDim(None, "pressure", (0.0, 1000.0), np.float64),
-        SharedDim(None, "temperature", (-200.0, 200.0), np.float64),
+        SharedDim("pressure", (0.0, 1000.0), np.float64),
+        SharedDim("temperature", (-200.0, 200.0), np.float64),
     ]
     creator = ArrayCreator(
         dim_order=("pressure", "temperature"), shared_dims=shared_dims, sparse=True
@@ -179,8 +179,8 @@ def test_dim_name_exists_error():
 
 def test_bad_tiles_error():
     shared_dims = [
-        SharedDim(None, "row", (0, 63), np.uint32),
-        SharedDim(None, "col", (0, 31), np.uint32),
+        SharedDim("row", (0, 63), np.uint32),
+        SharedDim("col", (0, 31), np.uint32),
     ]
     with pytest.raises(ValueError):
         ArrayCreator(shared_dims=shared_dims, dim_order=("row", "col"), tiles=(4,))
@@ -188,8 +188,8 @@ def test_bad_tiles_error():
 
 def test_to_schema_no_attrs_error():
     shared_dims = [
-        SharedDim(None, "row", (0, 63), np.uint32),
-        SharedDim(None, "col", (0, 31), np.uint32),
+        SharedDim("row", (0, 63), np.uint32),
+        SharedDim("col", (0, 31), np.uint32),
     ]
     creator = ArrayCreator(shared_dims=shared_dims, dim_order=("row", "col"))
     with pytest.raises(ValueError):
@@ -199,9 +199,9 @@ def test_to_schema_no_attrs_error():
 def test_inject_dim_creator_front():
     """Tests injecting a dimension into the front of the domain."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(shared_dims=shared_dims, dim_order=("x1", "x2"))
     creator.domain_creator.inject_dim_creator("x0", 0)
@@ -212,9 +212,9 @@ def test_inject_dim_creator_front():
 def test_inject_dim_creator_back():
     """Tests injecting a dimension into the back of the domain."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x3", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x3", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.inject_dim_creator("x3", -1)
@@ -225,9 +225,9 @@ def test_inject_dim_creator_back():
 def test_inject_dim_creator_middle():
     """Tests injecting a dimension into the middle of the domain."""
     shared_dims = [
-        SharedDim(None, "x0", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x1", (0, 4), np.uint32),
+        SharedDim("x0", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x1", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x2"), shared_dims=shared_dims)
     creator.domain_creator.inject_dim_creator("x1", 1)
@@ -239,9 +239,9 @@ def test_inject_dim_attr_name_conflict_error():
     """Tests error when injecting a dimension with name matching a current attribute
     name."""
     shared_dims = [
-        SharedDim(None, "x0", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x1", (0, 4), np.uint32),
+        SharedDim("x0", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x1", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x1"), shared_dims=shared_dims)
     creator.add_attr_creator("x2", dtype=np.int32)
@@ -253,8 +253,8 @@ def test_inject_dim_name_conflict_error():
     """Tests error when injecting a dimension with name matching a current dimension
     name."""
     shared_dims = [
-        SharedDim(None, "x0", (0, 7), np.uint32),
-        SharedDim(None, "x1", (0, 4), np.uint32),
+        SharedDim("x0", (0, 7), np.uint32),
+        SharedDim("x1", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x1"), shared_dims=shared_dims)
     with pytest.raises(ValueError):
@@ -265,9 +265,9 @@ def test_inject_dim_neg_out_of_bound_error():
     """Tests error when injecting a dimension when poviding a negative position that is
     one element out-of-bounds."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x2"), shared_dims=shared_dims)
     with pytest.raises(IndexError):
@@ -278,9 +278,9 @@ def test_inject_dim_pos_out_of_bound_error():
     """Tests error when injecting a dimension when providing a positive position that is
     one more than the size of the domain after creation."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x2"), shared_dims=shared_dims)
     with pytest.raises(IndexError):
@@ -290,9 +290,9 @@ def test_inject_dim_pos_out_of_bound_error():
 def test_remove_dim_creator_by_positive_int():
     """Tests removing a dimension using a positive dimension index."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator(0)
@@ -303,9 +303,9 @@ def test_remove_dim_creator_by_positive_int():
 def test_remove_dim_creator_by_negative_int():
     """Tests removing a dimension using a negative dimension index."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator(-3)
@@ -316,9 +316,9 @@ def test_remove_dim_creator_by_negative_int():
 def test_remove_dim_creator_front():
     """Tests removing the first dimension in the domain."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator("x0")
@@ -329,9 +329,9 @@ def test_remove_dim_creator_front():
 def test_remove_dim_creator_back():
     """Tests removing the last dimension in the domain."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x3", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x3", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x1", "x2", "x3"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator("x3")
@@ -342,9 +342,9 @@ def test_remove_dim_creator_back():
 def test_remove_dim_creator_middle():
     """Tests removing a dimension in the middle of the domain."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     creator.domain_creator.remove_dim_creator("x1")
@@ -356,9 +356,9 @@ def test_remove_dim_creator_position_index_error():
     """Tests attempting to remove a dimension that does not exist with a dimension
     index."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     with pytest.raises(IndexError):
@@ -368,9 +368,9 @@ def test_remove_dim_creator_position_index_error():
 def test_remove_dim_creator_name_key_error():
     """Tests attempting to remove a dimension that does not exist by name."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x0", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x0", (0, 4), np.uint32),
     ]
     creator = ArrayCreator(dim_order=("x0", "x1", "x2"), shared_dims=shared_dims)
     with pytest.raises(KeyError):

--- a/tests/core/test_array_creator.py
+++ b/tests/core/test_array_creator.py
@@ -31,7 +31,6 @@ class TestArrayCreatorSparseExample1:
 
     def test_create(self, tmpdir, array_creator):
         uri = str(tmpdir.mkdir("output").join("sparse_example_1"))
-        print(array_creator)
         array_creator.create(uri)
         assert tiledb.object_type(uri) == "array"
 

--- a/tests/core/test_shared_dimension.py
+++ b/tests/core/test_shared_dimension.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import tiledb
-from tiledb.cf.core._creator import DataspaceRegistry, SharedDim
+from tiledb.cf.core._creator import SharedDim
 
 _tiledb_dim = [
     tiledb.Dim(name="dim", domain=(1, 4), tile=4, dtype=np.int32),
@@ -20,9 +20,9 @@ _tiledb_dim = [
     ],
 )
 def test_is_index_dim(domain, dtype, result):
-    shared_dim = SharedDim(DataspaceRegistry(), "name", domain, dtype)
+    shared_dim = SharedDim(None, "name", domain, dtype)
     assert shared_dim.is_index_dim == result
 
 
 def test_compare_other_object():
-    assert SharedDim(DataspaceRegistry(), "dim", (1, 4), np.int32) != "not a dimension"
+    assert SharedDim(None, "dim", (1, 4), np.int32) != "not a dimension"

--- a/tests/core/test_shared_dimension.py
+++ b/tests/core/test_shared_dimension.py
@@ -20,9 +20,9 @@ _tiledb_dim = [
     ],
 )
 def test_is_index_dim(domain, dtype, result):
-    shared_dim = SharedDim(None, "name", domain, dtype)
+    shared_dim = SharedDim("name", domain, dtype)
     assert shared_dim.is_index_dim == result
 
 
 def test_compare_other_object():
-    assert SharedDim(None, "dim", (1, 4), np.int32) != "not a dimension"
+    assert SharedDim("dim", (1, 4), np.int32) != "not a dimension"

--- a/tests/netcdf_engine/test_netcdf4_converter_array.py
+++ b/tests/netcdf_engine/test_netcdf4_converter_array.py
@@ -19,9 +19,7 @@ class TestAttrsFilters:
             dim = dataset.createDimension("row", 64)
             var = dataset.createVariable("x", np.float64, ("row",))
             shared_dims = [
-                netcdf_engine.NetCDF4DimToDimConverter.from_netcdf(
-                    None, dim, None, np.uint64
-                )
+                netcdf_engine.NetCDF4DimToDimConverter.from_netcdf(dim, None, np.uint64)
             ]
             converter = netcdf_engine.NetCDF4ArrayConverter(
                 dim_order=("row",), shared_dims=shared_dims, attrs_filters=attrs_filters
@@ -38,9 +36,7 @@ class TestAttrsFilters:
             dim = dataset.createDimension("row", 64)
             var = dataset.createVariable("x", np.float64, ("row",))
             shared_dims = [
-                netcdf_engine.NetCDF4DimToDimConverter.from_netcdf(
-                    None, dim, None, np.uint64
-                )
+                netcdf_engine.NetCDF4DimToDimConverter.from_netcdf(dim, None, np.uint64)
             ]
             converter = netcdf_engine.NetCDF4ArrayConverter(
                 dim_order=("row",), shared_dims=shared_dims, attrs_filters=attrs_filters
@@ -52,9 +48,9 @@ class TestAttrsFilters:
 def test_remove_dim_creator_front():
     """Tests removing a dimension in the front of the domain."""
     shared_dims = [
-        SharedDim(None, "x0", (0, 7), np.uint32),
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 4), np.uint32),
+        SharedDim("x0", (0, 7), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 4), np.uint32),
     ]
     creator = netcdf_engine.NetCDF4ArrayConverter(
         dim_order=("x0", "x1", "x2"), shared_dims=shared_dims
@@ -67,9 +63,9 @@ def test_remove_dim_creator_front():
 def test_remove_dim_creator_back():
     """Tests removing a dimension in the back of the domain."""
     shared_dims = [
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 7), np.uint32),
-        SharedDim(None, "x3", (0, 4), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 7), np.uint32),
+        SharedDim("x3", (0, 4), np.uint32),
     ]
     creator = netcdf_engine.NetCDF4ArrayConverter(
         dim_order=("x1", "x2", "x3"), shared_dims=shared_dims
@@ -82,9 +78,9 @@ def test_remove_dim_creator_back():
 def test_remove_dim_creator_middle():
     """Tests removing a dimension in the middle of the domain."""
     shared_dims = [
-        SharedDim(None, "x0", (0, 7), np.uint32),
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 4), np.uint32),
+        SharedDim("x0", (0, 7), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 4), np.uint32),
     ]
     creator = netcdf_engine.NetCDF4ArrayConverter(
         dim_order=("x0", "x1", "x2"), shared_dims=shared_dims
@@ -97,9 +93,9 @@ def test_remove_dim_creator_middle():
 def test_remove_dim_creator_key_error():
     """Tests key error when removing a dimension by name."""
     shared_dims = [
-        SharedDim(None, "x0", (0, 7), np.uint32),
-        SharedDim(None, "x1", (0, 7), np.uint32),
-        SharedDim(None, "x2", (0, 4), np.uint32),
+        SharedDim("x0", (0, 7), np.uint32),
+        SharedDim("x1", (0, 7), np.uint32),
+        SharedDim("x2", (0, 4), np.uint32),
     ]
     creator = netcdf_engine.NetCDF4ArrayConverter(
         dim_order=("x0", "x1", "x2"), shared_dims=shared_dims
@@ -111,7 +107,7 @@ def test_remove_dim_creator_key_error():
 def test_set_max_fragment_shape_error():
     """Tests raising an error when attempting to set max_fragment_shape with a value
     that is a bad length."""
-    shared_dims = [SharedDim(None, "x", (0, 7), np.uint32)]
+    shared_dims = [SharedDim("x", (0, 7), np.uint32)]
     creator = netcdf_engine.NetCDF4ArrayConverter(
         dim_order=("x"), shared_dims=shared_dims
     )
@@ -122,7 +118,7 @@ def test_set_max_fragment_shape_error():
 
 def test_array_converter_indexer_error():
     """Tests value error when copying with an indexer of bad length."""
-    shared_dims = [SharedDim(None, "x", (0, 7), np.uint32)]
+    shared_dims = [SharedDim("x", (0, 7), np.uint32)]
     creator = netcdf_engine.NetCDF4ArrayConverter(
         dim_order=("x"), shared_dims=shared_dims
     )

--- a/tests/netcdf_engine/test_netcdf4_converter_engine.py
+++ b/tests/netcdf_engine/test_netcdf4_converter_engine.py
@@ -1097,7 +1097,7 @@ def test_variable_fill(tmpdir):
         dataset.createDimension("row", 4)
         dataset.createVariable("x1", np.dtype("int64"), ("row",), fill_value=-1)
         converter = NetCDF4ConverterEngine.from_group(dataset, coords_to_dims=False)
-        attr_creator = converter._registry.get_attr_creator("x1")
+        attr_creator = converter._core.get_attr_creator("x1")
         assert attr_creator.fill == -1
 
 

--- a/tests/netcdf_engine/test_netcdf4_to_dim_base.py
+++ b/tests/netcdf_engine/test_netcdf4_to_dim_base.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from tiledb.cf.core._creator import DataspaceRegistry
 from tiledb.cf.netcdf_engine import (
     NetCDF4CoordToDimConverter,
     NetCDF4DimToDimConverter,
@@ -29,8 +28,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = np.random.rand((8))
-            registry = DataspaceRegistry()
-            converter = NetCDF4CoordToDimConverter.from_netcdf(registry, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
             assert converter.name == var.name
             assert converter.domain is None
             assert converter.dtype == np.dtype(np.float64)
@@ -54,8 +52,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = data
-            registry = DataspaceRegistry()
-            converter = NetCDF4CoordToDimConverter.from_netcdf(registry, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
             result = converter.get_values(dataset, sparse=True, indexer=indexer)
         np.testing.assert_equal(result, data[indexer])
 
@@ -65,8 +62,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = data
-            registry = DataspaceRegistry()
-            converter = NetCDF4CoordToDimConverter.from_netcdf(registry, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
             query_size = converter.get_query_size(dataset)
         np.testing.assert_equal(query_size, 8)
 
@@ -74,8 +70,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
-            registry = DataspaceRegistry()
-            converter = NetCDF4CoordToDimConverter.from_netcdf(registry, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
             with pytest.raises(ValueError):
                 converter.get_values(dataset, sparse=True, indexer=slice(None))
 
@@ -85,8 +80,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = data
-            registry = DataspaceRegistry()
-            converter = NetCDF4CoordToDimConverter.from_netcdf(registry, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
             with pytest.raises(NotImplementedError):
                 converter.get_values(dataset, sparse=False, indexer=slice(None))
 
@@ -96,8 +90,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = data
-            registry = DataspaceRegistry()
-            converter = NetCDF4CoordToDimConverter.from_netcdf(registry, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
             with pytest.raises(ValueError):
                 converter.get_values(dataset, sparse=False, indexer=slice(0, 8, 2))
 
@@ -105,8 +98,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
-            registry = DataspaceRegistry()
-            converter = NetCDF4CoordToDimConverter.from_netcdf(registry, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
             group = dataset.createGroup("group1")
             with pytest.raises(KeyError):
                 converter.get_values(group, sparse=True, indexer=slice(None))
@@ -115,8 +107,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
-            registry = DataspaceRegistry()
-            converter = NetCDF4CoordToDimConverter.from_netcdf(registry, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
             group = dataset.createGroup("group1")
             group.createVariable("value", np.float64, tuple())
             with pytest.raises(ValueError):
@@ -134,10 +125,7 @@ class TestNetCDFDimToDimConverterSimpleDim:
     def test_class_properties(self):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 1000, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
             assert isinstance(repr(converter), str)
             assert converter.input_dim_name == dim.name
             assert converter.input_dim_size == dim.size
@@ -152,20 +140,14 @@ class TestNetCDFDimToDimConverterSimpleDim:
     def test_get_values(self, sparse, values):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 1000, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
             result = converter.get_values(dataset, sparse=sparse, indexer=slice(None))
             np.testing.assert_equal(result, values)
 
     def test_get_query_size(self):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 1000, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
             query_size = converter.get_query_size(dataset)
             np.testing.assert_equal(query_size, 8)
 
@@ -176,20 +158,14 @@ class TestNetCDFDimToDimConverterSimpleDim:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
             group = dataset.createGroup("group1")
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 1000, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
             result = converter.get_values(group, sparse=sparse, indexer=slice(None))
             np.testing.assert_equal(result, values)
 
     def test_no_dim_error(self):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 1000, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
         with netCDF4.Dataset("no_dims.nc", mode="w", diskless=True) as dataset:
             group = dataset.createGroup("group")
             with pytest.raises(KeyError):
@@ -198,10 +174,7 @@ class TestNetCDFDimToDimConverterSimpleDim:
     def test_get_values_bad_step_error(self):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 1000, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
             with pytest.raises(ValueError):
                 converter.get_values(dataset, sparse=False, indexer=slice(0, 8, 2))
 
@@ -214,9 +187,8 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", None)
             max_size = 100
-            registry = DataspaceRegistry()
             converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, max_size, np.uint64
+                None, dim, max_size, np.uint64
             )
             assert isinstance(repr(converter), str)
             assert converter.input_dim_name == dim.name
@@ -230,10 +202,7 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
     def test_get_values_no_data(self, sparse):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", None)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 100, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 100, np.uint64)
             with pytest.raises(IndexError):
                 converter.get_values(dataset, sparse=sparse, indexer=slice(None))
 
@@ -252,10 +221,7 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
             var = dataset.createVariable("data", np.int32, ("row",))
             size = 10
             var[:] = np.arange(size)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 100, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 100, np.uint64)
             result = converter.get_values(dataset, sparse=sparse, indexer=indexer)
             np.testing.assert_equal(result, expected_result)
 
@@ -265,10 +231,7 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
             var = dataset.createVariable("data", np.int32, ("row",))
             size = 10
             var[:] = np.arange(size)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 100, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 100, np.uint64)
             query_size = converter.get_query_size(dataset)
             np.testing.assert_equal(query_size, size)
 
@@ -278,25 +241,20 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
             var = dataset.createVariable("data", np.int32, ("row",))
             size = 11
             var[:] = np.arange(size)
-            registry = DataspaceRegistry()
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                registry, dim, 10, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 10, np.uint64)
             with pytest.raises(IndexError):
                 converter.get_values(dataset, sparse=True, indexer=slice(None))
 
 
 class TestNetCDFScalarToDimConverter:
     def test_class_properties(self):
-        registry = DataspaceRegistry()
-        converter = NetCDF4ScalarToDimConverter.create(registry, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
         assert converter.name == "__scalars"
         assert converter.domain == (0, 0)
         assert converter.dtype == np.dtype(np.uint32)
 
     def test_repr(self):
-        registry = DataspaceRegistry()
-        converter = NetCDF4ScalarToDimConverter.create(registry, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
         isinstance(repr(converter), str)
 
     @pytest.mark.parametrize(
@@ -308,36 +266,31 @@ class TestNetCDFScalarToDimConverter:
         ],
     )
     def test_get_values(self, sparse, indexer, expected_result):
-        registry = DataspaceRegistry()
-        converter = NetCDF4ScalarToDimConverter.create(registry, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             result = converter.get_values(dataset, sparse=sparse, indexer=indexer)
             np.testing.assert_equal(result, expected_result)
 
     def test_get_values_bad_step_error(self):
-        registry = DataspaceRegistry()
-        converter = NetCDF4ScalarToDimConverter.create(registry, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             with pytest.raises(ValueError):
                 converter.get_values(dataset, sparse=False, indexer=slice(0, 1, -1))
 
     def test_get_values_bad_start_error(self):
-        registry = DataspaceRegistry()
-        converter = NetCDF4ScalarToDimConverter.create(registry, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             with pytest.raises(IndexError):
                 converter.get_values(dataset, sparse=False, indexer=slice(-1, 1))
 
     def test_get_values_bad_stop_error(self):
-        registry = DataspaceRegistry()
-        converter = NetCDF4ScalarToDimConverter.create(registry, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             with pytest.raises(IndexError):
                 converter.get_values(dataset, sparse=False, indexer=slice(0, 10))
 
     def test_get_query_size(self):
-        registry = DataspaceRegistry()
-        converter = NetCDF4ScalarToDimConverter.create(registry, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             result = converter.get_query_size(dataset)
             np.testing.assert_equal(result, 1)

--- a/tests/netcdf_engine/test_netcdf4_to_dim_base.py
+++ b/tests/netcdf_engine/test_netcdf4_to_dim_base.py
@@ -28,7 +28,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = np.random.rand((8))
-            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(var)
             assert converter.name == var.name
             assert converter.domain is None
             assert converter.dtype == np.dtype(np.float64)
@@ -52,7 +52,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = data
-            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(var)
             result = converter.get_values(dataset, sparse=True, indexer=indexer)
         np.testing.assert_equal(result, data[indexer])
 
@@ -62,7 +62,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = data
-            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(var)
             query_size = converter.get_query_size(dataset)
         np.testing.assert_equal(query_size, 8)
 
@@ -70,7 +70,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
-            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(var)
             with pytest.raises(ValueError):
                 converter.get_values(dataset, sparse=True, indexer=slice(None))
 
@@ -80,7 +80,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = data
-            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(var)
             with pytest.raises(NotImplementedError):
                 converter.get_values(dataset, sparse=False, indexer=slice(None))
 
@@ -90,7 +90,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
             var[:] = data
-            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(var)
             with pytest.raises(ValueError):
                 converter.get_values(dataset, sparse=False, indexer=slice(0, 8, 2))
 
@@ -98,7 +98,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
-            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(var)
             group = dataset.createGroup("group1")
             with pytest.raises(KeyError):
                 converter.get_values(group, sparse=True, indexer=slice(None))
@@ -107,7 +107,7 @@ class TestNetCDFCoordToDimConverterUnlimCoord:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dataset.createDimension("value")
             var = dataset.createVariable("value", np.float64, ("value",))
-            converter = NetCDF4CoordToDimConverter.from_netcdf(None, var)
+            converter = NetCDF4CoordToDimConverter.from_netcdf(var)
             group = dataset.createGroup("group1")
             group.createVariable("value", np.float64, tuple())
             with pytest.raises(ValueError):
@@ -125,7 +125,7 @@ class TestNetCDFDimToDimConverterSimpleDim:
     def test_class_properties(self):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 1000, np.uint64)
             assert isinstance(repr(converter), str)
             assert converter.input_dim_name == dim.name
             assert converter.input_dim_size == dim.size
@@ -140,14 +140,14 @@ class TestNetCDFDimToDimConverterSimpleDim:
     def test_get_values(self, sparse, values):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 1000, np.uint64)
             result = converter.get_values(dataset, sparse=sparse, indexer=slice(None))
             np.testing.assert_equal(result, values)
 
     def test_get_query_size(self):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 1000, np.uint64)
             query_size = converter.get_query_size(dataset)
             np.testing.assert_equal(query_size, 8)
 
@@ -158,14 +158,14 @@ class TestNetCDFDimToDimConverterSimpleDim:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
             group = dataset.createGroup("group1")
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 1000, np.uint64)
             result = converter.get_values(group, sparse=sparse, indexer=slice(None))
             np.testing.assert_equal(result, values)
 
     def test_no_dim_error(self):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 1000, np.uint64)
         with netCDF4.Dataset("no_dims.nc", mode="w", diskless=True) as dataset:
             group = dataset.createGroup("group")
             with pytest.raises(KeyError):
@@ -174,7 +174,7 @@ class TestNetCDFDimToDimConverterSimpleDim:
     def test_get_values_bad_step_error(self):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", 8)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 1000, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 1000, np.uint64)
             with pytest.raises(ValueError):
                 converter.get_values(dataset, sparse=False, indexer=slice(0, 8, 2))
 
@@ -187,9 +187,7 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", None)
             max_size = 100
-            converter = NetCDF4DimToDimConverter.from_netcdf(
-                None, dim, max_size, np.uint64
-            )
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, max_size, np.uint64)
             assert isinstance(repr(converter), str)
             assert converter.input_dim_name == dim.name
             assert converter.input_dim_size == dim.size
@@ -202,7 +200,7 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
     def test_get_values_no_data(self, sparse):
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             dim = dataset.createDimension("row", None)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 100, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 100, np.uint64)
             with pytest.raises(IndexError):
                 converter.get_values(dataset, sparse=sparse, indexer=slice(None))
 
@@ -221,7 +219,7 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
             var = dataset.createVariable("data", np.int32, ("row",))
             size = 10
             var[:] = np.arange(size)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 100, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 100, np.uint64)
             result = converter.get_values(dataset, sparse=sparse, indexer=indexer)
             np.testing.assert_equal(result, expected_result)
 
@@ -231,7 +229,7 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
             var = dataset.createVariable("data", np.int32, ("row",))
             size = 10
             var[:] = np.arange(size)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 100, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 100, np.uint64)
             query_size = converter.get_query_size(dataset)
             np.testing.assert_equal(query_size, size)
 
@@ -241,20 +239,20 @@ class TestNetCDFDimToDimConverterUnlimitedDim:
             var = dataset.createVariable("data", np.int32, ("row",))
             size = 11
             var[:] = np.arange(size)
-            converter = NetCDF4DimToDimConverter.from_netcdf(None, dim, 10, np.uint64)
+            converter = NetCDF4DimToDimConverter.from_netcdf(dim, 10, np.uint64)
             with pytest.raises(IndexError):
                 converter.get_values(dataset, sparse=True, indexer=slice(None))
 
 
 class TestNetCDFScalarToDimConverter:
     def test_class_properties(self):
-        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create("__scalars", np.uint32)
         assert converter.name == "__scalars"
         assert converter.domain == (0, 0)
         assert converter.dtype == np.dtype(np.uint32)
 
     def test_repr(self):
-        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create("__scalars", np.uint32)
         isinstance(repr(converter), str)
 
     @pytest.mark.parametrize(
@@ -266,31 +264,31 @@ class TestNetCDFScalarToDimConverter:
         ],
     )
     def test_get_values(self, sparse, indexer, expected_result):
-        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create("__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             result = converter.get_values(dataset, sparse=sparse, indexer=indexer)
             np.testing.assert_equal(result, expected_result)
 
     def test_get_values_bad_step_error(self):
-        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create("__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             with pytest.raises(ValueError):
                 converter.get_values(dataset, sparse=False, indexer=slice(0, 1, -1))
 
     def test_get_values_bad_start_error(self):
-        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create("__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             with pytest.raises(IndexError):
                 converter.get_values(dataset, sparse=False, indexer=slice(-1, 1))
 
     def test_get_values_bad_stop_error(self):
-        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create("__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             with pytest.raises(IndexError):
                 converter.get_values(dataset, sparse=False, indexer=slice(0, 10))
 
     def test_get_query_size(self):
-        converter = NetCDF4ScalarToDimConverter.create(None, "__scalars", np.uint32)
+        converter = NetCDF4ScalarToDimConverter.create("__scalars", np.uint32)
         with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
             result = converter.get_query_size(dataset)
             np.testing.assert_equal(result, 1)

--- a/tests/netcdf_engine/test_netcdf4_to_dim_converter.py
+++ b/tests/netcdf_engine/test_netcdf4_to_dim_converter.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from tiledb.cf.core._creator import DataspaceRegistry, SharedDim
+from tiledb.cf.core._creator import SharedDim
 from tiledb.cf.netcdf_engine import NetCDF4ToDimConverter
 
 netCDF4 = pytest.importorskip("netCDF4")
@@ -10,12 +10,11 @@ netCDF4 = pytest.importorskip("netCDF4")
 class TestSharedDimBase:
     """This class tests the NetCDF4ToDimConverter for a non-NetCDF dimension."""
 
-    registry = DataspaceRegistry()
     shared_dim = SharedDim(
         name="dim0",
         dtype=np.dtype("int32"),
         domain=(0, 31),
-        dataspace_registry=registry,
+        registry=None,
     )
 
     def test_default_properties(self):

--- a/tests/netcdf_engine/test_netcdf_coord_to_dim_converter.py
+++ b/tests/netcdf_engine/test_netcdf_coord_to_dim_converter.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from tiledb.cf.core._creator import DataspaceRegistry
 from tiledb.cf.netcdf_engine import NetCDF4CoordToDimConverter
 
 netCDF4 = pytest.importorskip("netCDF4")
@@ -11,8 +10,7 @@ def test_coord_converter_simple():
     with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
         dataset.createDimension("x", 4)
         x = dataset.createVariable("x", datatype=np.float64, dimensions=("x",))
-        registry = DataspaceRegistry()
-        converter = NetCDF4CoordToDimConverter.from_netcdf(registry, x)
+        converter = NetCDF4CoordToDimConverter.from_netcdf(None, x)
         assert converter.name == "x"
         assert converter.dtype == np.dtype("float64")
         assert converter.domain is None
@@ -26,5 +24,4 @@ def test_bad_size_error():
             "x", datatype=np.dtype("float64"), dimensions=("x", "y")
         )
         with pytest.raises(ValueError):
-            registry = DataspaceRegistry()
-            NetCDF4CoordToDimConverter.from_netcdf(registry, x)
+            NetCDF4CoordToDimConverter.from_netcdf(None, x)

--- a/tests/netcdf_engine/test_netcdf_coord_to_dim_converter.py
+++ b/tests/netcdf_engine/test_netcdf_coord_to_dim_converter.py
@@ -10,7 +10,7 @@ def test_coord_converter_simple():
     with netCDF4.Dataset("example.nc", mode="w", diskless=True) as dataset:
         dataset.createDimension("x", 4)
         x = dataset.createVariable("x", datatype=np.float64, dimensions=("x",))
-        converter = NetCDF4CoordToDimConverter.from_netcdf(None, x)
+        converter = NetCDF4CoordToDimConverter.from_netcdf(x)
         assert converter.name == "x"
         assert converter.dtype == np.dtype("float64")
         assert converter.domain is None
@@ -24,4 +24,4 @@ def test_bad_size_error():
             "x", datatype=np.dtype("float64"), dimensions=("x", "y")
         )
         with pytest.raises(ValueError):
-            NetCDF4CoordToDimConverter.from_netcdf(None, x)
+            NetCDF4CoordToDimConverter.from_netcdf(x)

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -1025,7 +1025,7 @@ class AttrCreator(RegisteredByName, metaclass=ABCMeta):
 class DomainCreator:
     """Creator for a TileDB domain."""
 
-    def __init__(self, array_core):
+    def __init__(self, array_core: ArrayCreatorCore):
         self._core = array_core
 
     def __iter__(self):
@@ -1108,6 +1108,7 @@ class DimCreator:
     def __init__(
         self,
         base: SharedDim,
+        *,
         tile: Optional[Union[int, float]] = None,
         filters: Optional[Union[tiledb.FilterList]] = None,
     ):

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -469,7 +469,7 @@ class DataspaceDomain(MutableMapping):
 
     def __setitem__(self, name: str, value: SharedDim):
         if value.is_registered:
-            raise ValueError(f"SharedDim '{value.name}' is already registered.")
+            raise ValueError(f"Shared dimension '{value.name}' is already registered.")
         if name != value.name:
             value.name = name
         self._core.register_shared_dim(value)

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from io import StringIO
-from typing import Any, Dict, Iterable, Optional, Self, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union
 
 import numpy as np
+from typing_extensions import Self
 
 import tiledb
 

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -436,7 +436,7 @@ class DataspaceArrayRegistry(MutableMapping):
         return self._core.array_creators()
 
     def __len__(self) -> int:
-        return self._crore.naarray
+        return self._core.narray
 
     def __setitem__(self, name: str, value: ArrayCreator):
         if value.is_registered:
@@ -483,11 +483,6 @@ class ArrayDimRegistry:
         self._shared_dims: Dict[str, SharedDim] = dict()
 
     def __delitem__(self, name: str):
-        if name in self._in_use:
-            raise ValueError(
-                f"Cannot remove shared dimension '{name}' that is being used by "
-                f"an array."
-            )
         del self._shared_dims[name]
 
     def __getitem__(self, name: str) -> SharedDim:
@@ -541,7 +536,7 @@ class ArrayCreator(RegisteredByNameMixin):
         self,
         *,
         name: str = "array",
-        dim_order: Sequence[str] = None,
+        dim_order: Optional[Sequence[str]] = None,
         cell_order: str = "row-major",
         tile_order: str = "row-major",
         capacity: int = 0,
@@ -785,7 +780,7 @@ class ArrayCreator(RegisteredByNameMixin):
 
 
 class ArrayCreatorCore:
-    def __init__(self, dim_registry: Registry[SharedDim], array_dims: Tuple[str, ...]):
+    def __init__(self, dim_registry: Registry[SharedDim], array_dims: Sequence[str]):
         self._dim_registry = dim_registry
         self._dim_creators = tuple(
             self._new_dim_creator(dim_name) for dim_name in array_dims
@@ -858,7 +853,7 @@ class ArrayCreatorCore:
                 return index
         raise KeyError(f"Dimension creator with name '{dim_name}' not found.")
 
-    def has_attr_creator(self, name: str) -> AttrCreator:
+    def has_attr_creator(self, name: str) -> bool:
         """Returns if an attribute creator with the requested name is in the array
         creator
 
@@ -938,7 +933,7 @@ class ArrayAttrRegistry:
         self._core.deregister_attr_creator(name)
 
     def __getitem__(self, name: str) -> AttrCreator:
-        self._core.get_attr_creator(name)
+        return self._core.get_attr_creator(name)
 
     def __setitem__(self, name: str, value: AttrCreator):
         if value.is_registered:

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -174,7 +174,7 @@ class DataspaceCreator:
             domain: The (inclusive) interval on which the dimension is valid.
             dtype: The numpy dtype of the values and domain of the dimension.
         """
-        SharedDim(self._dim_registry, dim_name, domain, dtype)
+        SharedDim(dim_name, domain, dtype, registry=self._dim_registry)
 
     def array_creators(self):
         """Iterates over array creators in the CF dataspace."""
@@ -1115,10 +1115,11 @@ class SharedDim(RegisteredByName, metaclass=ABCMeta):
 
     def __init__(
         self,
-        registry: Optional[Registry[Self]],
         name: str,
         domain: Optional[Tuple[Optional[DType], Optional[DType]]],
         dtype: np.dtype,
+        *,
+        registry: Optional[Registry[Self]] = None,
     ):
         self._name = name
         self.domain = domain

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -428,11 +428,11 @@ class DataspaceDimRegistry:
         self._registry.deregister_shared_dim(name)
 
     def __getitem__(self, name: str) -> SharedDim:
-        self._impl.get_shared_dim(name)
+        return self._impl.get_shared_dim(name)
 
     def __setitem__(self, name: str, value: SharedDim):
         if value.is_registered:
-            raise ValueError("SharedDim '{value.name}' is already registered.")
+            raise ValueError(f"SharedDim '{value.name}' is already registered.")
         if name != value.name:
             value.name = name
         self._impl.register_shared_dim(value)

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from abc import ABCMeta
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from io import StringIO
@@ -14,7 +13,7 @@ import tiledb
 
 from .._utils import DType
 from .api import create_group
-from .registry import RegisteredByName, Registry
+from .registry import RegisteredByNameMixin, Registry
 
 
 class DataspaceCreator:
@@ -519,7 +518,7 @@ class ArrayDimRegistry:
         self._shared_dims[new_name] = self._shared_dims.pop(old_name)
 
 
-class ArrayCreator(RegisteredByName):
+class ArrayCreator(RegisteredByNameMixin):
     """Creator for a TileDB array using shared dimension definitions.
 
     Attributes:
@@ -595,9 +594,7 @@ class ArrayCreator(RegisteredByName):
         self.sparse = sparse
 
         # Set name and registry for the array creator.
-        self._name = name
-        self._registry = None
-        self.set_registry(registry)
+        super().__init__(name, registry)
 
     def __iter__(self):
         """Returns iterator over attribute creators."""
@@ -955,7 +952,7 @@ class ArrayAttrRegistry:
         self._core.update_attr_creator_name(old_name, new_name)
 
 
-class AttrCreator(RegisteredByName, metaclass=ABCMeta):
+class AttrCreator(RegisteredByNameMixin):
     """Creator for a TileDB attribute.
 
     Attributes:
@@ -978,14 +975,12 @@ class AttrCreator(RegisteredByName, metaclass=ABCMeta):
         filters: Optional[tiledb.FilterList] = None,
         registry: Optional[Registry[Self]] = None,
     ):
-        self._name = name
         self.dtype = np.dtype(dtype)
         self.fill = fill
         self.var = var
         self.nullable = nullable
         self.filters = filters
-        self._registry = None
-        self.set_registry(registry)
+        super().__init__(name, registry)
 
     def __repr__(self):
         filters_str = f", filters=FilterList({self.filters})" if self.filters else ""
@@ -1182,7 +1177,7 @@ class DimCreator:
         )
 
 
-class SharedDim(RegisteredByName, metaclass=ABCMeta):
+class SharedDim(RegisteredByNameMixin):
     """Definition for the name, domain and data type of a collection of dimensions."""
 
     def __init__(
@@ -1196,8 +1191,7 @@ class SharedDim(RegisteredByName, metaclass=ABCMeta):
         self._name = name
         self.domain = domain
         self.dtype = np.dtype(dtype)
-        self._registry = None
-        self.set_registry(registry)
+        super().__init__(name, registry)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/tiledb/cf/core/_creator.py
+++ b/tiledb/cf/core/_creator.py
@@ -1079,7 +1079,7 @@ class SharedDim(metaclass=ABCMeta):
 
     def __init__(
         self,
-        dataspace_registry: DataspaceRegistry,
+        registry: Optional[DataspaceRegistry],
         name: str,
         domain: Optional[Tuple[Optional[DType], Optional[DType]]],
         dtype: np.dtype,
@@ -1087,8 +1087,9 @@ class SharedDim(metaclass=ABCMeta):
         self._name = name
         self.domain = domain
         self.dtype = np.dtype(dtype)
-        self._dataspace_registry = dataspace_registry
-        self._dataspace_registry.register_shared_dim(self)
+        self._registry = registry
+        if registry is not None:
+            self._registry.register_shared_dim(self)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -1132,6 +1133,21 @@ class SharedDim(metaclass=ABCMeta):
 
     @name.setter
     def name(self, name: str):
-        self._dataspace_registry.check_rename_shared_dim(self._name, name)
-        self._dataspace_registry.update_shared_dim_name(self._name, name)
+        if self._registry is not None:
+            self._registry.check_rename_shared_dim(self._name, name)
+            self._registry.update_shared_dim_name(self._name, name)
         self._name = name
+
+    @property
+    def registry(self) -> Optional[DataspaceRegistry]:
+        return self._registry
+
+    @registry.setter
+    def registry(self, registry: DataspaceRegistry):
+        if self._registry is not None:
+            raise ValueError(
+                "Cannot register a shared dimension that is already registered."
+            )
+        self._registry = registry
+        if self._registry is not None:
+            self._registry.register_shared_dim(self)

--- a/tiledb/cf/core/registry.py
+++ b/tiledb/cf/core/registry.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Optional, Protocol, Self, TypeVar
+from typing import Optional, TypeVar
+
+from typing_extensions import Protocol, Self
 
 T = TypeVar("T")
 
@@ -28,7 +30,7 @@ class Registry(Protocol[T]):
 class RegisteredByNameMixin:
     def __init__(self, name: str, registry: Optional[Registry[Self]]):
         self._name = name
-        self._registry = None
+        self._registry: Optional[Registry[Self]] = None
         self.set_registry(registry)
 
     @property

--- a/tiledb/cf/core/registry.py
+++ b/tiledb/cf/core/registry.py
@@ -1,3 +1,7 @@
+"""Create a name registry for use in modifying grouped objects."""
+
+from __future__ import annotations
+
 from typing import Optional, Protocol, Self, TypeVar
 
 T = TypeVar("T")
@@ -21,7 +25,12 @@ class Registry(Protocol[T]):
         ...
 
 
-class RegisteredByName:
+class RegisteredByNameMixin:
+    def __init__(self, name: str, registry: Optional[Registry[Self]]):
+        self._name = name
+        self._registry = None
+        self.set_registry(registry)
+
     @property
     def is_registered(self) -> bool:
         return self._registry is not None

--- a/tiledb/cf/core/registry.py
+++ b/tiledb/cf/core/registry.py
@@ -1,0 +1,44 @@
+from typing import Optional, Protocol, Self, TypeVar
+
+T = TypeVar("T")
+
+
+class Registry(Protocol[T]):
+    def __delitem__(self, name: str):
+        ...
+
+    def __getitem__(self, name: str) -> T:
+        ...
+
+    def __setitem__(self, name: str, value: T):
+        ...
+
+    def rename(self, old_name: str, new_name: str):
+        """Rename an element of the registry.
+
+        If the rename fails, the registry should be left unchanged.
+        """
+        ...
+
+
+class RegisteredByName:
+    @property
+    def is_registered(self) -> bool:
+        return self._registry is not None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, name: str):
+        if self._registry is not None:
+            self._registry.rename(self.name, name)
+        self._name = name
+
+    def set_registry(self, registry: Optional[Registry[Self]]):
+        if self._registry is not None:
+            raise ValueError("Registry for is already set.")
+        if registry is not None:
+            registry[self.name] = self
+        self._registry = registry

--- a/tiledb/cf/core/registry.py
+++ b/tiledb/cf/core/registry.py
@@ -38,7 +38,7 @@ class RegisteredByName:
 
     def set_registry(self, registry: Optional[Registry[Self]]):
         if self._registry is not None:
-            raise ValueError("Registry for is already set.")
+            raise ValueError("Registry is already set.")
         if registry is not None:
             registry[self.name] = self
         self._registry = registry

--- a/tiledb/cf/netcdf_engine/_array_converters.py
+++ b/tiledb/cf/netcdf_engine/_array_converters.py
@@ -9,7 +9,7 @@ import numpy as np
 import tiledb
 from tiledb.cf.core._creator import (
     ArrayCreator,
-    ArrayRegistry,
+    ArrayCreatorCore,
     DataspaceRegistry,
     DomainCreator,
 )
@@ -81,16 +81,13 @@ class NetCDF4ArrayConverter(ArrayCreator):
         )
         tiledb_array[coord_values] = data
 
-    def _register(
-        self, dataspace_registry: DataspaceRegistry, name: str, dim_names: Sequence[str]
+    def _new_core(
+        self, dataspace_registry: DataspaceRegistry, dim_names: Sequence[str]
     ):
-        shared_dims = map(dataspace_registry.get_shared_dim, dim_names)
-        dim_creators = tuple(map(NetCDF4ToDimConverter, shared_dims))
-        array_registry = ArrayRegistry(dataspace_registry, name, dim_creators)
-        return (
-            array_registry,
-            NetCDF4DomainConverter(array_registry, dataspace_registry),
-        )
+        return NetCDF4ArrayConverterCore(dataspace_registry, dim_names)
+
+    def _new_domain_creator(self):
+        return NetCDF4DomainConverter(self._core)
 
     def add_var_to_attr_converter(
         self,
@@ -201,6 +198,54 @@ class NetCDF4ArrayConverter(ArrayCreator):
                 )
 
 
+class NetCDF4ArrayConverterCore(ArrayCreatorCore):
+    def _new_dim_creator(self, dim_name: str, **kwargs):
+        return NetCDF4ToDimConverter(
+            self._dataspace_registry.get_shared_dim(dim_name), **kwargs
+        )
+
+    def inject_dim_creator(self, dim_name: str, position: int, **dim_kwargs):
+        """Add an additional dimension into the domain of the array.
+
+        Parameters:
+            dim_name: Name of the shared dimension to add to the array's domain.
+            position: Position of the shared dimension. Negative values count backwards
+                from the end of the new number of dimensions.
+            dim_kwargs: Keyword arguments to pass to :class:`NetCDF4ToDimConverter`.
+        """
+        dim_creator = NetCDF4ToDimConverter(
+            self._dataspace_registry.get_shared_dim(dim_name), **dim_kwargs
+        )
+        if dim_creator.is_from_netcdf:
+            if any(
+                isinstance(attr_creator, NetCDF4VarToAttrConverter)
+                for attr_creator in self.attr_creators()
+            ):
+                raise ValueError(
+                    "Cannot add a new NetCDF dimension converter to an array that "
+                    "already contains NetCDF variable to attribute converters."
+                )
+        if dim_creator.name in {dim_creator.name for dim_creator in self._dim_creators}:
+            raise ValueError(
+                f"Cannot add dimension creator `{dim_creator.name}` to this array. "
+                f"That dimension is already in use."
+            )
+        if dim_creator.name in self._attr_creators:
+            raise ValueError(
+                f"Cannot add dimension creator `{dim_creator.name}` to this array. An "
+                f"attribute creator with that name already exists."
+            )
+        index = self.ndim + 1 + position if position < 0 else position
+        if index < 0 or index > self.ndim:
+            raise IndexError(
+                f"Cannot add dimension to position {position} for an array with "
+                f"{self.ndim} dimensions."
+            )
+        self._dim_creators = (
+            self._dim_creators[:index] + (dim_creator,) + self._dim_creators[index:]
+        )
+
+
 class NetCDF4DomainConverter(DomainCreator):
     """Converter for NetCDF dimensions to a TileDB domain."""
 
@@ -247,19 +292,7 @@ class NetCDF4DomainConverter(DomainCreator):
                 from the end of the new number of dimensions.
             dim_kwargs: Keyword arguments to pass to :class:`NetCDF4ToDimConverter`.
         """
-        dim_creator = NetCDF4ToDimConverter(
-            self._dataspace_registry.get_shared_dim(dim_name), **dim_kwargs
-        )
-        if dim_creator.is_from_netcdf:
-            if any(
-                isinstance(attr_creator, NetCDF4VarToAttrConverter)
-                for attr_creator in self._array_registry.attr_creators()
-            ):
-                raise ValueError(
-                    "Cannot add a new NetCDF dimension converter to an array that "
-                    "already contains NetCDF variable to attribute converters."
-                )
-        self._array_registry.inject_dim_creator(dim_creator, position)
+        self._core.inject_dim_creator(dim_name, position, **dim_kwargs)
 
     @property
     def max_fragment_shape(self):
@@ -299,16 +332,16 @@ class NetCDF4DomainConverter(DomainCreator):
         index = (
             dim_id
             if isinstance(dim_id, int)
-            else self._array_registry.get_dim_position_by_name(dim_id)
+            else self._core.get_dim_position_by_name(dim_id)
         )
-        dim_creator = self._array_registry.get_dim_creator(index)
+        dim_creator = self._core.get_dim_creator(index)
         if isinstance(dim_creator.base, NetCDF4ToDimBase):
             if any(
                 isinstance(attr_creator, NetCDF4VarToAttrConverter)
-                for attr_creator in self._array_registry.attr_creators()
+                for attr_creator in self._core.attr_creators()
             ):
                 raise ValueError(
                     "Cannot remove NetCDF dimension converter from an array that "
                     "contains NetCDF variable to attribute converters."
                 )
-        self._array_registry.remove_dim_creator(index)
+        self._core.remove_dim_creator(index)

--- a/tiledb/cf/netcdf_engine/_array_converters.py
+++ b/tiledb/cf/netcdf_engine/_array_converters.py
@@ -135,7 +135,7 @@ class NetCDF4ArrayConverter(ArrayCreator):
         if filters is None:
             filters = self.attrs_filters
         NetCDF4VarToAttrConverter.from_netcdf(
-            array_registry=self._registry,
+            registry=self._attr_registry,
             ncvar=ncvar,
             name=name,
             dtype=dtype,

--- a/tiledb/cf/netcdf_engine/_attr_converters.py
+++ b/tiledb/cf/netcdf_engine/_attr_converters.py
@@ -1,7 +1,7 @@
 """Classes for converting NetCDF4 objects to TileDB attributes."""
 
 from abc import abstractmethod
-from typing import Optional, Sequence, Self, Union
+from typing import Optional, Self, Sequence, Union
 
 import netCDF4
 import numpy as np

--- a/tiledb/cf/netcdf_engine/_attr_converters.py
+++ b/tiledb/cf/netcdf_engine/_attr_converters.py
@@ -1,10 +1,11 @@
 """Classes for converting NetCDF4 objects to TileDB attributes."""
 
 from abc import abstractmethod
-from typing import Optional, Self, Sequence, Union
+from typing import Optional, Sequence, Union
 
 import netCDF4
 import numpy as np
+from typing_extensions import Self
 
 import tiledb
 from tiledb.cf.core import AttrMetadata

--- a/tiledb/cf/netcdf_engine/_attr_converters.py
+++ b/tiledb/cf/netcdf_engine/_attr_converters.py
@@ -1,15 +1,16 @@
 """Classes for converting NetCDF4 objects to TileDB attributes."""
 
 from abc import abstractmethod
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Self, Union
 
 import netCDF4
 import numpy as np
 
 import tiledb
 from tiledb.cf.core import AttrMetadata
-from tiledb.cf.core._creator import ArrayRegistry, AttrCreator
+from tiledb.cf.core._creator import AttrCreator
 
+from ..core.registry import Registry
 from ._utils import (
     COORDINATE_SUFFIX,
     get_netcdf_metadata,
@@ -70,7 +71,6 @@ class NetCDF4VarToAttrConverter(NetCDF4ToAttrConverter):
 
     def __init__(
         self,
-        array_registry: ArrayRegistry,
         name: str,
         dtype: np.dtype,
         fill: Optional[Union[int, float, str]],
@@ -80,9 +80,11 @@ class NetCDF4VarToAttrConverter(NetCDF4ToAttrConverter):
         input_var_name: str,
         input_var_dtype: np.dtype,
         unpack: bool,
+        *,
+        registry: Optional[Registry[Self]] = None,
     ):
         super().__init__(
-            array_registry=array_registry,
+            registry=registry,
             name=name,
             dtype=dtype,
             fill=fill,
@@ -132,8 +134,8 @@ class NetCDF4VarToAttrConverter(NetCDF4ToAttrConverter):
     @classmethod
     def from_netcdf(
         cls,
-        array_registry: ArrayRegistry,
         ncvar: netCDF4.Variable,
+        *,
         name: Optional[str] = None,
         dtype: Optional[np.dtype] = None,
         fill: Optional[Union[int, float, str]] = None,
@@ -141,6 +143,7 @@ class NetCDF4VarToAttrConverter(NetCDF4ToAttrConverter):
         nullable: bool = False,
         filters: Optional[tiledb.FilterList] = None,
         unpack: bool = False,
+        registry: Optional[Registry[Self]] = None,
     ):
         if fill is None:
             fill = get_netcdf_metadata(ncvar, "_FillValue")
@@ -154,7 +157,7 @@ class NetCDF4VarToAttrConverter(NetCDF4ToAttrConverter):
             dtype = get_unpacked_dtype(ncvar) if unpack else ncvar.dtype
         dtype = np.dtype(dtype)
         return cls(
-            array_registry=array_registry,
+            registry=registry,
             name=name,
             dtype=dtype,
             fill=fill,

--- a/tiledb/cf/netcdf_engine/_dim_converters.py
+++ b/tiledb/cf/netcdf_engine/_dim_converters.py
@@ -174,7 +174,7 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
 
     def __init__(
         self,
-        dataspace_registry: DataspaceRegistry,
+        dataspace_registry: Optional[DataspaceRegistry],
         name: str,
         domain: Optional[Tuple[Optional[DType], Optional[DType]]],
         dtype: np.dtype,
@@ -236,7 +236,7 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
     @classmethod
     def from_netcdf(
         cls,
-        dataspace_registry: DataspaceRegistry,
+        dataspace_registry: Optional[DataspaceRegistry],
         ncvar: netCDF4.Variable,
         name: Optional[str] = None,
         domain: Optional[Tuple[DType, DType]] = None,
@@ -325,7 +325,7 @@ class NetCDF4DimToDimConverter(NetCDF4ToDimBase):
 
     def __init__(
         self,
-        dataspace_registry: DataspaceRegistry,
+        dataspace_registry: Optional[DataspaceRegistry],
         name: str,
         domain: Optional[Tuple[Optional[DType], Optional[DType]]],
         dtype: np.dtype,
@@ -368,7 +368,7 @@ class NetCDF4DimToDimConverter(NetCDF4ToDimBase):
     @classmethod
     def from_netcdf(
         cls,
-        dataspace_registry: DataspaceRegistry,
+        dataspace_registry: Optional[DataspaceRegistry],
         dim: netCDF4.Dimension,
         unlimited_dim_size: Optional[int],
         dtype: np.dtype,
@@ -456,7 +456,10 @@ class NetCDF4ScalarToDimConverter(NetCDF4ToDimBase):
 
     @classmethod
     def create(
-        cls, dataspace_registry: DataspaceRegistry, dim_name: str, dtype: np.dtype
+        cls,
+        dataspace_registry: Optional[DataspaceRegistry],
+        dim_name: str,
+        dtype: np.dtype,
     ):
         return cls(dataspace_registry, dim_name, (0, 0), dtype)
 

--- a/tiledb/cf/netcdf_engine/_dim_converters.py
+++ b/tiledb/cf/netcdf_engine/_dim_converters.py
@@ -2,7 +2,7 @@
 
 import itertools
 from abc import abstractmethod
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, Optional, Self, Tuple, Union
 
 import netCDF4
 import numpy as np
@@ -12,6 +12,7 @@ from tiledb.cf.core import DimMetadata
 from tiledb.cf.core._creator import DataspaceRegistry, DimCreator, SharedDim
 
 from .._utils import DType
+from ..core.registry import Registry
 from ._utils import get_unpacked_dtype, get_variable_values, safe_set_metadata
 
 
@@ -174,7 +175,7 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
 
     def __init__(
         self,
-        dataspace_registry: Optional[DataspaceRegistry],
+        registry: Optional[Registry[Self]],
         name: str,
         domain: Optional[Tuple[Optional[DType], Optional[DType]]],
         dtype: np.dtype,
@@ -183,7 +184,7 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
         input_var_dtype: np.dtype,
         unpack: bool,
     ):
-        super().__init__(dataspace_registry, name, domain, dtype)
+        super().__init__(registry, name, domain, dtype)
         self.input_dim_name = input_dim_name
         self.input_var_name = input_var_name
         self.input_var_dtype = input_var_dtype
@@ -236,7 +237,7 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
     @classmethod
     def from_netcdf(
         cls,
-        dataspace_registry: Optional[DataspaceRegistry],
+        registry: Optional[DataspaceRegistry],
         ncvar: netCDF4.Variable,
         name: Optional[str] = None,
         domain: Optional[Tuple[DType, DType]] = None,
@@ -252,7 +253,7 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
             dtype = get_unpacked_dtype(ncvar) if unpack else ncvar.dtype
         dtype = np.dtype(dtype)
         return cls(
-            dataspace_registry=dataspace_registry,
+            registry=registry,
             name=name if name is not None else ncvar.name,
             domain=domain,
             dtype=dtype,
@@ -325,7 +326,7 @@ class NetCDF4DimToDimConverter(NetCDF4ToDimBase):
 
     def __init__(
         self,
-        dataspace_registry: Optional[DataspaceRegistry],
+        registry: Optional[Registry[Self]],
         name: str,
         domain: Optional[Tuple[Optional[DType], Optional[DType]]],
         dtype: np.dtype,
@@ -333,7 +334,7 @@ class NetCDF4DimToDimConverter(NetCDF4ToDimBase):
         input_dim_size: int,
         is_unlimited: bool,
     ):
-        super().__init__(dataspace_registry, name, domain, dtype)
+        super().__init__(registry, name, domain, dtype)
         self.input_dim_name = input_dim_name
         self.input_dim_size = input_dim_size
         self.is_unlimited = is_unlimited
@@ -368,7 +369,7 @@ class NetCDF4DimToDimConverter(NetCDF4ToDimBase):
     @classmethod
     def from_netcdf(
         cls,
-        dataspace_registry: Optional[DataspaceRegistry],
+        registry: Optional[DataspaceRegistry],
         dim: netCDF4.Dimension,
         unlimited_dim_size: Optional[int],
         dtype: np.dtype,
@@ -380,7 +381,7 @@ class NetCDF4DimToDimConverter(NetCDF4ToDimBase):
             else dim.size
         )
         return cls(
-            dataspace_registry=dataspace_registry,
+            registry=registry,
             name=name if name is not None else dim.name,
             domain=(0, size - 1),
             dtype=dtype,
@@ -457,11 +458,11 @@ class NetCDF4ScalarToDimConverter(NetCDF4ToDimBase):
     @classmethod
     def create(
         cls,
-        dataspace_registry: Optional[DataspaceRegistry],
+        registry: Optional[DataspaceRegistry],
         dim_name: str,
         dtype: np.dtype,
     ):
-        return cls(dataspace_registry, dim_name, (0, 0), dtype)
+        return cls(registry, dim_name, (0, 0), dtype)
 
     def get_query_size(self, netcdf_group: netCDF4.Dataset):
         """Returns the number of coordinates to copy from NetCDF to TileDB.

--- a/tiledb/cf/netcdf_engine/_dim_converters.py
+++ b/tiledb/cf/netcdf_engine/_dim_converters.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import tiledb
 from tiledb.cf.core import DimMetadata
-from tiledb.cf.core._creator import DataspaceRegistry, DimCreator, SharedDim
+from tiledb.cf.core._creator import DimCreator, SharedDim
 
 from .._utils import DType
 from ..core.registry import Registry
@@ -175,7 +175,6 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
 
     def __init__(
         self,
-        registry: Optional[Registry[Self]],
         name: str,
         domain: Optional[Tuple[Optional[DType], Optional[DType]]],
         dtype: np.dtype,
@@ -183,8 +182,10 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
         input_var_name: str,
         input_var_dtype: np.dtype,
         unpack: bool,
+        *,
+        registry: Optional[Registry[Self]] = None,
     ):
-        super().__init__(registry, name, domain, dtype)
+        super().__init__(name, domain, dtype, registry=registry)
         self.input_dim_name = input_dim_name
         self.input_var_name = input_var_name
         self.input_var_dtype = input_var_dtype
@@ -237,12 +238,13 @@ class NetCDF4CoordToDimConverter(NetCDF4ToDimBase):
     @classmethod
     def from_netcdf(
         cls,
-        registry: Optional[DataspaceRegistry],
         ncvar: netCDF4.Variable,
+        *,
         name: Optional[str] = None,
         domain: Optional[Tuple[DType, DType]] = None,
         dtype: Optional[np.dtype] = None,
         unpack: bool = False,
+        registry: Optional[Registry[Self]] = None,
     ):
         if len(ncvar.dimensions) != 1:
             raise ValueError(
@@ -326,15 +328,16 @@ class NetCDF4DimToDimConverter(NetCDF4ToDimBase):
 
     def __init__(
         self,
-        registry: Optional[Registry[Self]],
         name: str,
         domain: Optional[Tuple[Optional[DType], Optional[DType]]],
         dtype: np.dtype,
         input_dim_name: str,
         input_dim_size: int,
         is_unlimited: bool,
+        *,
+        registry: Optional[Registry[Self]],
     ):
-        super().__init__(registry, name, domain, dtype)
+        super().__init__(name, domain, dtype, registry=registry)
         self.input_dim_name = input_dim_name
         self.input_dim_size = input_dim_size
         self.is_unlimited = is_unlimited
@@ -369,11 +372,12 @@ class NetCDF4DimToDimConverter(NetCDF4ToDimBase):
     @classmethod
     def from_netcdf(
         cls,
-        registry: Optional[DataspaceRegistry],
         dim: netCDF4.Dimension,
         unlimited_dim_size: Optional[int],
         dtype: np.dtype,
+        *,
         name: Optional[str] = None,
+        registry: Optional[Registry[Self]] = None,
     ):
         size = (
             unlimited_dim_size
@@ -458,11 +462,12 @@ class NetCDF4ScalarToDimConverter(NetCDF4ToDimBase):
     @classmethod
     def create(
         cls,
-        registry: Optional[DataspaceRegistry],
         dim_name: str,
         dtype: np.dtype,
+        *,
+        registry: Optional[Registry[Self]] = None,
     ):
-        return cls(registry, dim_name, (0, 0), dtype)
+        return cls(dim_name, (0, 0), dtype, registry=registry)
 
     def get_query_size(self, netcdf_group: netCDF4.Dataset):
         """Returns the number of coordinates to copy from NetCDF to TileDB.

--- a/tiledb/cf/netcdf_engine/_dim_converters.py
+++ b/tiledb/cf/netcdf_engine/_dim_converters.py
@@ -28,6 +28,7 @@ class NetCDF4ToDimConverter(DimCreator):
     def __init__(
         self,
         base: SharedDim,
+        *,
         tile: Optional[Union[int, float]] = None,
         filters: Optional[tiledb.FilterList] = None,
         max_fragment_length: Optional[int] = None,

--- a/tiledb/cf/netcdf_engine/_dim_converters.py
+++ b/tiledb/cf/netcdf_engine/_dim_converters.py
@@ -2,10 +2,11 @@
 
 import itertools
 from abc import abstractmethod
-from typing import Any, Dict, Iterable, Optional, Self, Tuple, Union
+from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import netCDF4
 import numpy as np
+from typing_extensions import Self
 
 import tiledb
 from tiledb.cf.core import DimMetadata

--- a/tiledb/cf/netcdf_engine/converter.py
+++ b/tiledb/cf/netcdf_engine/converter.py
@@ -466,7 +466,8 @@ class NetCDF4ConverterEngine(DataspaceCreator):
                 TileDB array (false).
         """
         NetCDF4ArrayConverter(
-            dataspace_registry=self._registry,
+            registry=self._array_registry,
+            dim_registry=self._dim_registry,
             name=array_name,
             dim_order=dims,
             cell_order=cell_order,

--- a/tiledb/cf/netcdf_engine/converter.py
+++ b/tiledb/cf/netcdf_engine/converter.py
@@ -468,7 +468,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
         NetCDF4ArrayConverter(
             dataspace_registry=self._registry,
             name=array_name,
-            dims=dims,
+            dim_order=dims,
             cell_order=cell_order,
             tile_order=tile_order,
             capacity=capacity,

--- a/tiledb/cf/netcdf_engine/converter.py
+++ b/tiledb/cf/netcdf_engine/converter.py
@@ -501,7 +501,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
 
         """
         NetCDF4CoordToDimConverter.from_netcdf(
-            dataspace_registry=self._registry,
+            registry=self._dim_registry,
             ncvar=ncvar,
             name=dim_name,
             domain=domain,
@@ -526,7 +526,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             dim_name: If not ``None``, output name of the TileDB dimension.
         """
         NetCDF4DimToDimConverter.from_netcdf(
-            dataspace_registry=self._registry,
+            registry=self._dim_registry,
             dim=ncdim,
             unlimited_dim_size=unlimited_dim_size,
             dtype=dtype,
@@ -545,7 +545,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             dtype: Numpy type to use for the scalar dimension
         """
         NetCDF4ScalarToDimConverter.create(
-            dataspace_registry=self._registry, dim_name=dim_name, dtype=dtype
+            registry=self._dim_registry, dim_name=dim_name, dtype=dtype
         )
 
     def add_var_to_attr_converter(

--- a/tiledb/cf/netcdf_engine/converter.py
+++ b/tiledb/cf/netcdf_engine/converter.py
@@ -467,7 +467,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
         """
         NetCDF4ArrayConverter(
             registry=self._array_registry,
-            dim_registry=self._dim_registry,
+            dim_registry=self._domain,
             name=array_name,
             dim_order=dims,
             cell_order=cell_order,
@@ -502,7 +502,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
 
         """
         NetCDF4CoordToDimConverter.from_netcdf(
-            registry=self._dim_registry,
+            registry=self._domain,
             ncvar=ncvar,
             name=dim_name,
             domain=domain,
@@ -527,7 +527,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             dim_name: If not ``None``, output name of the TileDB dimension.
         """
         NetCDF4DimToDimConverter.from_netcdf(
-            registry=self._dim_registry,
+            registry=self._domain,
             dim=ncdim,
             unlimited_dim_size=unlimited_dim_size,
             dtype=dtype,
@@ -546,7 +546,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             dtype: Numpy type to use for the scalar dimension
         """
         NetCDF4ScalarToDimConverter.create(
-            registry=self._dim_registry, dim_name=dim_name, dtype=dtype
+            registry=self._domain, dim_name=dim_name, dtype=dtype
         )
 
     def add_var_to_attr_converter(
@@ -583,7 +583,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
                 unpack``.
         """
         try:
-            array_creator = self._registry.get_array_creator(array_name)
+            array_creator = self._core.get_array_creator(array_name)
         except KeyError as err:  # pragma: no cover
             raise KeyError(
                 f"Cannot add attribute to array '{array_name}'. No array named "
@@ -743,13 +743,13 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             copy_metadata: If  ``True`` copy NetCDF group and variable attributes to
                 TileDB metadata. If ``False`` do not copy metadata.
         """
-        if self._registry.narray != 1:  # pragma: no cover
+        if self._core.narray != 1:  # pragma: no cover
             raise ValueError(
                 f"Can only use `copy_to_array` for a {self.__class__.__name__} with "
                 f"exactly 1 array creator. This {self.__class__.__name__} contains "
-                f"{self._registry.narray} array creators."
+                f"{self._core.narray} array creators."
             )
-        array_creator = next(self._registry.array_creators())
+        array_creator = next(self._core.array_creators())
         if input_netcdf_group is None:
             input_file = (
                 input_file if input_file is not None else self.default_input_file
@@ -827,7 +827,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             )
         array_uris = {
             array_creator.name: os.path.join(output_uri, array_creator.name)
-            for array_creator in self._registry.array_creators()
+            for array_creator in self._core.array_creators()
         }
         if input_netcdf_group is None:
             input_file = (
@@ -844,7 +844,7 @@ class NetCDF4ConverterEngine(DataspaceCreator):
             if copy_metadata:
                 with tiledb.Group(output_uri, mode="w", ctx=ctx) as group:
                     copy_group_metadata(netcdf_group, group.meta)
-            for array_creator in self._registry.array_creators():
+            for array_creator in self._core.array_creators():
                 if isinstance(array_creator, NetCDF4ArrayConverter):
                     array_creator.copy(
                         netcdf_group=netcdf_group,


### PR DESCRIPTION
* Add and use `Registry` protocol and `RegisteredByName` superclass
* Make optional `__init__` parameters kwargs only for internal classes
* Make registry optional for `ArrayCreator`, `AttrCreator`, and `SharedDim`
